### PR TITLE
Fix Backend-Override to use mirror in staging

### DIFF
--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -246,6 +246,10 @@ ${private_extra_vcl_recv}
     set req.http.original-url = req.url;
   }
 
+  %{ if environment == "staging" }
+  set var.backend_override = req.http.Backend-Override;
+  %{ endif ~}
+
   # Common config when failover to mirror buckets
   if (req.restarts > 0 || std.prefixof(var.backend_override, "mirror")) {
     set req.url = req.http.original-url;


### PR DESCRIPTION
There was a statement missing the set the variable to enable selecting the backend when the "Backend-Override" header was set in staging.