### PR TITLE
Remove Govuk-Use-Recommended-Related-Links header

### DIFF
--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -224,10 +224,6 @@ ${private_extra_vcl_recv}
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
-  # Set header to show recommended related links for Whitehall content. This is to be used
-  # as a rollback mechanism should we ever need to stop showing these links.
-  set req.http.Govuk-Use-Recommended-Related-Links = "true";
-
   # Set a request id header to allow requests to be traced through the stack
   set req.http.GOVUK-Request-Id = uuid.version4();
 


### PR DESCRIPTION
## Context

As an outcome of RFC-163, we are trying to simplify our CDN configuration by removing functionality that’s no longer used, or by moving logic to other parts of the stack.

This change was suggested in a comment on RFC-163
(https://github.com/alphagov/govuk-rfcs/pull/163#discussion_r1289816022):

"I think the flag for Whitehall recommended links should be removed. It was put in as a safety mechanism for the introduction of the links, in case something really inappropriate was found. There are ways to manually override the links now, and we've never used the feature flag."

The application logic dependent on this header is removed in https://github.com/alphagov/government-frontend/pull/2918

It's now recommended to create feature flags as environment variables in helm charts.

[Trello card](https://trello.com/c/3iHLzrSq/3288-remove-whitehall-recommended-related-links-feature-flag-3)

## Depends on

- https://github.com/alphagov/government-frontend/pull/2918