### PR TITLE
Update the % for ElasticSearch 6.7 AA test

### DIFF
--- a/ab_tests.yaml
+++ b/ab_tests.yaml
@@ -10,3 +10,4 @@
 - EsSixPointSeven:
   - A
   - B
+  - C

--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -14,5 +14,6 @@ bankholidaystest_percentages:
   A: 99
   B: 1
 essixpointseven_percentages:
-  A: 50
-  B: 50
+  A: 0.5
+  B: 0.5
+  C: 99


### PR DESCRIPTION
The `essixpointseven` AA test is currently deployed at a 50/50 variant split. This PR updates the AA test to throttle the split to 0.5%. 

The C variant has been added to make the difference between the CDN traffic allocation and anything that falls into the Z variant (handled by the rendering app) more explicit.

[The rendering app code has been updated in this PR to handle the C variant](https://github.com/alphagov/finder-frontend/pull/3149).

This PR was [originally opened](https://github.com/alphagov/govuk-cdn-config/pull/470) on the govuk-cdn-config repo which has been archived. Therefore it has been re-added here and I will close the other PR.