### PR TITLE
Remove autodiscover 404 logic

### DIFF
--- a/modules/bouncer/bouncer.vcl.tftpl
+++ b/modules/bouncer/bouncer.vcl.tftpl
@@ -50,11 +50,6 @@ sub vcl_recv {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
-  # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
-  if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
-    error 804 "Not Found";
-  }
-
   ${indent(2, file("${module_path}/../shared/_security_txt_request.vcl"))}
 
   # Serve from stale for 24 hours if origin is sick

--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -203,11 +203,6 @@ sub vcl_recv {
 ${private_extra_vcl_recv}
   %{ endif ~}
 
-  # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
-  if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
-    error 804 "Not Found";
-  }
-
   ${indent(2, file("${module_path}/../shared/_security_txt_request.vcl"))}
 
   # Sort query params (improve cache hit rate)


### PR DESCRIPTION
Remove VCL code as this logic is handled by AWS WAF

Trello: https://trello.com/c/tprMplI9/3293-move-logic-for-serving-an-http-404-if-request-url-matches-autodiscover-autodiscoverxml-from-cdn-to-waf-3