### PR TITLE
Temporarily allow requests for the homepage to retain query strings

### DIFF
--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -222,11 +222,6 @@ ${private_extra_vcl_recv}
   # Set a request id header to allow requests to be traced through the stack
   set req.http.GOVUK-Request-Id = uuid.version4();
 
-  if (req.url.path == "/") {
-    # get rid of all query parameters
-    set req.url = querystring.remove(req.url);
-  }
-
   if (req.url.path ~ "^\/alerts(?:\/|$)") {
     # get rid of all query parameters
     set req.url = querystring.remove(req.url);


### PR DESCRIPTION
## What
Temporarily allow requests for the homepage to retain query strings

## Why
A new design of the gov.uk homepage is being rolled out. To prevent a big bang release, and increase confidence, we intend to ship those changes piecemeal, hiding them behind a query string. 

## How
Remove the logic originally added in https://github.com/alphagov/govuk-cdn-config/commit/37eacc22f418d579d3bf14b27eaca4ae6cc96d55. We assume that it was added to improve caching performance. 

