### PR TITLE
Remove private_extra_vcl_recv

### DIFF
--- a/modules/www/service.tf
+++ b/modules/www/service.tf
@@ -24,7 +24,6 @@ locals {
       gcs_mirror_probe = null
       gcs_mirror_port = 443
 
-      private_extra_vcl_recv = ""
       ab_tests = []
     },
     { # computed values

--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -199,9 +199,6 @@ sub vcl_recv {
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
   }
-  %{ if private_extra_vcl_recv != "" ~}
-${private_extra_vcl_recv}
-  %{ endif ~}
 
   ${indent(2, file("${module_path}/../shared/_security_txt_request.vcl"))}
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/vr0xCoVR/3308-move-contact-form-honeypot-from-cdn-into-waf-5)

This functionality is no longer needed after merging alphagov/govuk-fastly-secrets#6 (more details are available in that PR's description)