### PR TITLE
Remove obsolete IP from the office IP range

### DIFF
--- a/modules/bouncer/bouncer.vcl.tftpl
+++ b/modules/bouncer/bouncer.vcl.tftpl
@@ -30,14 +30,6 @@ backend sick_force_grace {
 
 acl purge_ip_allowlist {
   # See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/gds-internal-it/gds-internal-it-network-public-ip-addresses
-  "213.86.153.211";  # GDS Office (BYOD VPN)
-  "213.86.153.212";  # GDS Office
-  "213.86.153.213";  # GDS Office
-  "213.86.153.214";  # GDS Office
-  "213.86.153.231";  # GDS Office (BYOD VPN)
-  "213.86.153.235";  # GDS Office
-  "213.86.153.236";  # GDS Office
-  "213.86.153.237";  # GDS Office
   "51.149.8.0"/25;   # GDS Office (DR VPN)
   "51.149.8.128"/29; # GDS Office (DR BYOD VPN)
   "217.196.229.77";  # GDS Office


### PR DESCRIPTION
See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-gds/gds-internal-it/gds-internal-it-network-public-ip-addresses