### PR TITLE
Use req.http.True-Client-IP when testing for original client IP.

### DIFF
--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -163,7 +163,7 @@ sub vcl_recv {
   }
   %{ if environment == "staging" }
   # Only allow connections from allowed IP addresses in staging
-  if (! (client.ip ~ allowed_ip_addresses)) {
+  if (! (req.http.True-Client-IP ~ allowed_ip_addresses)) {
     error 403 "Forbidden";
   }
   %{ endif ~}


### PR DESCRIPTION
In staging we test the client IP to allow access only to office or VPN IPs. However when using shielding in Fastly, the client.ip variable may be set to a Fastly server. By using True-Client-IP instead, we conserve the IP of the original client.