### PR TITLE
Fix serving fonts via the mirror backends

### DIFF
--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -250,7 +250,7 @@ sub vcl_recv {
     set req.url = regsuball(req.url, "([^:])//+", "\1/");
 
     # Requests without document extension, rewrite adding .html
-    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
+    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|woff|woff2|zip)([\?#]+.*)?$") {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
   }


### PR DESCRIPTION
This change prevents Fastly from adding ".html" to the end of requests for ".woff" or ".woff2" font types.