### PR TITLE
Enable accessing mirrored version of GOV.UK in prod

### DIFF
--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -229,7 +229,7 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
-  %{ if environment == "staging" }
+  %{ if contains(["staging", "production"], environment) }
   set var.backend_override = req.http.Backend-Override;
   %{ endif ~}
 


### PR DESCRIPTION
This is enabled through setting a header to override the backend in which to retrieve content. This has been tested in Staging.