### PR TITLE
Pin only to major versions to reduce Dependabot toil.

### DIFF
--- a/diff-generator/Dockerfile
+++ b/diff-generator/Dockerfile
@@ -3,7 +3,7 @@ FROM public.ecr.aws/lts/ubuntu:22.04_stable
 RUN apt update && \
   apt install -y --no-install-recommends python3 python3-pip npm && \
   rm -r /var/lib/apt/lists /var/cache/apt/archives && \
-  npm install -g diff2html-cli@5.2.9
+  npm install -g diff2html-cli@5
 
 WORKDIR /function
 

--- a/diff-generator/requirements.txt
+++ b/diff-generator/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.31.0
-awslambdaric==2.0.7
-boto3==1.28.70
+requests>=2.31,<3
+awslambdaric>=2.0.7,<3
+boto3>=1.28.70,<2


### PR DESCRIPTION
Tested: `docker build .` works locally.