### PR TITLE
Update purge_ip_allowlist to reflect recent changes.

### DIFF
--- a/modules/bouncer/bouncer.vcl.tftpl
+++ b/modules/bouncer/bouncer.vcl.tftpl
@@ -29,13 +29,12 @@ backend sick_force_grace {
 
 
 acl purge_ip_allowlist {
-  # See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/gds-internal-it/gds-internal-it-network-public-ip-addresses
-  "51.149.8.0"/25;   # GDS Office (DR VPN)
-  "51.149.8.128"/29; # GDS Office (DR BYOD VPN)
-  "217.196.229.77";  # GDS Office
-  "217.196.229.79";  # GDS Office
-  "217.196.229.80";  # GDS Office (BYOD VPN)
-  "217.196.229.81";  # GDS Office
+  # https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/gds-internal-it/gds-internal-it-network-public-ip-addresses
+  "217.196.229.77";
+  "217.196.229.79";
+  "217.196.229.80"/31;
+  "51.149.8.0"/25;
+  "51.149.8.128"/29;
 }
 
 sub vcl_recv {


### PR DESCRIPTION
Update the ACL reflect the changes to [GDS Office and VPN Public IP Addresses](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-gds/gds-internal-it/gds-internal-it-network-public-ip-addresses) which came into effect on 1 Oct.