### PR TITLE
Remove deprecated use of Fastly-Cachetype header

### DIFF
--- a/modules/assets/assets.vcl.tftpl
+++ b/modules/assets/assets.vcl.tftpl
@@ -275,7 +275,6 @@ sub vcl_fetch {
   }
 
   if (beresp.http.Cache-Control ~ "private") {
-    set req.http.Fastly-Cachetype = "PRIVATE";
     return (pass);
   }
 
@@ -288,7 +287,6 @@ sub vcl_fetch {
   }
 
   if (beresp.status >= 500 && beresp.status <= 599) {
-    set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
     if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {

--- a/modules/bouncer/bouncer.vcl.tftpl
+++ b/modules/bouncer/bouncer.vcl.tftpl
@@ -85,17 +85,14 @@ sub vcl_fetch {
   }
 
   if (beresp.http.Set-Cookie) {
-    set req.http.Fastly-Cachetype = "SETCOOKIE";
     return (pass);
   }
 
   if (beresp.http.Cache-Control ~ "private") {
-    set req.http.Fastly-Cachetype = "PRIVATE";
     return (pass);
   }
 
   if (beresp.status == 500 || beresp.status == 503) {
-    set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
     return (deliver);

--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -387,7 +387,6 @@ sub vcl_fetch {
   }
 
   if (beresp.status >= 500 && beresp.status <= 599) {
-    set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
     if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
@@ -397,7 +396,6 @@ sub vcl_fetch {
   }
 
   if (beresp.http.Cache-Control ~ "private") {
-    set req.http.Fastly-Cachetype = "PRIVATE";
     return (pass);
   }
 


### PR DESCRIPTION
It's unused by Fastly and has been deprecated. For more information see https://developer.fastly.com/reference/http/http-headers/Fastly-Cachetype/

Trello card: https://trello.com/c/1oMeBT0O/3356-remove-deprecated-use-of-fastly-cachetype-header-2