### PR TITLE
Setup vertex search ab test

### DIFF
--- a/ab_tests.yaml
+++ b/ab_tests.yaml
@@ -11,3 +11,7 @@
   - A
   - B
   - Z
+- VertexSearch:
+  - A
+  - B
+  - Z  

--- a/ab_tests.yaml
+++ b/ab_tests.yaml
@@ -7,9 +7,6 @@
 - BankHolidaysTest:
   - A
   - B
-- EsSixPointSeven:
-  - A
-  - B
 - FindUtrNumberVideoLinks:
   - A
   - B

--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -2,10 +2,12 @@ active_ab_tests:
   Example: true
   BankHolidaysTest: true
   FindUtrNumberVideoLinks: true
+  VertexSearch: true
 ab_test_expiries:
   Example: 86400
   BankHolidaysTest: 86400
   FindUtrNumberVideoLinks: 7776000 # 90 days
+  VertexSearch: 86400
 # AB test percentages
 example_percentages:
   A: 50
@@ -17,3 +19,7 @@ findutrnumbervideolinks_percentages:
   A: 50
   B: 50
   Z: 0
+vertexsearch_percentages:
+  A: 0
+  B: 0
+  Z: 100

--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -1,12 +1,10 @@
 active_ab_tests:
   Example: true
   BankHolidaysTest: true
-  EsSixPointSeven: true
   FindUtrNumberVideoLinks: true
 ab_test_expiries:
   Example: 86400
   BankHolidaysTest: 86400
-  EsSixPointSeven: 86400
   FindUtrNumberVideoLinks: 7776000 # 90 days
 # AB test percentages
 example_percentages:
@@ -15,9 +13,6 @@ example_percentages:
 bankholidaystest_percentages:
   A: 99
   B: 1
-essixpointseven_percentages:
-  A: 50
-  B: 50
 findutrnumbervideolinks_percentages:
   A: 50
   B: 50


### PR DESCRIPTION
Trello: https://trello.com/c/XAPAI9sT/212-set-up-ab-test-for-new-search-on-govuk-platform

The new test will use the same Dimension (41) as the old Elastic search A/A control test.