### PR TITLE
Add data.gov.uk

### DIFF
--- a/datagovuk.tf
+++ b/datagovuk.tf
@@ -13,35 +13,3 @@ module "datagovuk-integration" {
 
   secrets = yamldecode(var.datagovuk_integration)
 }
-
-variable "datagovuk_staging" {
-  type = string
-}
-
-module "datagovuk-staging" {
-  source = "./modules/datagovuk"
-
-  configuration = {
-    environment = "staging"
-    git_hash = var.TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA
-    probe = "/"
-  }
-
-  secrets = yamldecode(var.datagovuk_staging)
-}
-
-variable "datagovuk_production" {
-  type = string
-}
-
-module "datagovuk-production" {
-  source = "./modules/datagovuk"
-
-  configuration = {
-    environment = "production"
-    git_hash = var.TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA
-    probe = "/"
-  }
-
-  secrets = yamldecode(var.datagovuk_production)
-}

--- a/datagovuk.tf
+++ b/datagovuk.tf
@@ -1,0 +1,47 @@
+variable "datagovuk_integration" {
+  type = string
+}
+
+module "datagovuk-integration" {
+  source = "./modules/datagovuk"
+
+  configuration = {
+    environment = "integration"
+    git_hash = var.TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA
+    probe = "/"
+  }
+
+  secrets = yamldecode(var.datagovuk_integration)
+}
+
+variable "datagovuk_staging" {
+  type = string
+}
+
+module "datagovuk-staging" {
+  source = "./modules/datagovuk"
+
+  configuration = {
+    environment = "staging"
+    git_hash = var.TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA
+    probe = "/"
+  }
+
+  secrets = yamldecode(var.datagovuk_staging)
+}
+
+variable "datagovuk_production" {
+  type = string
+}
+
+module "datagovuk-production" {
+  source = "./modules/datagovuk"
+
+  configuration = {
+    environment = "production"
+    git_hash = var.TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA
+    probe = "/"
+  }
+
+  secrets = yamldecode(var.datagovuk_production)
+}

--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -140,6 +140,11 @@ backend F_mirrorGCS {
 sub vcl_recv {
   ${indent(2, file("${module_path}/../shared/_boundary_headers.vcl.tftpl"))}
 
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_denylist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -173,6 +173,13 @@ sub vcl_recv {
   }
   %{ endif ~}
 
+  # Strip Accept-Encoding header if the content is already compressed
+  if (req.http.Accept-Encoding) {
+    if (req.url ~ "\.(jpeg|jpg|png|gif|gz|tgz|bz2|tbz|zip|flv|pdf|mp3|ogg)$") {
+      remove req.http.Accept-Encoding;
+    }
+  }
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -1,0 +1,337 @@
+backend F_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "${origin_port}";
+    .host = "${origin_hostname}";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "${minimum_tls_version}";
+    .ssl_ciphers = "${ssl_ciphers}";
+    .ssl_cert_hostname = "${origin_hostname}";
+    .ssl_sni_hostname = "${origin_hostname}";
+
+%{ if probe != null ~}
+    .probe = {
+        .dummy = ${probe_dns_only};
+        .request =
+            "HEAD ${probe} HTTP/1.1"
+            "Host: ${origin_hostname}"
+            "User-Agent: Fastly healthcheck (Git commit: ${git_hash})"
+            "Rate-Limit-Token: ${rate_limit_token}"
+%{ if basic_authentication != null ~}
+            "Authorization: Basic ${basic_authentication}"
+%{ endif ~}
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = ${probe_interval};
+    }
+%{ endif ~}
+}
+
+%{ if contains(["staging", "production"], environment) }
+# Mirror backend for S3
+backend F_mirrorS3 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "${s3_mirror_port}";
+    .host = "${s3_mirror_hostname}";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "${minimum_tls_version}";
+    .ssl_ciphers = "${ssl_ciphers}";
+    .ssl_cert_hostname = "${s3_mirror_hostname}";
+    .ssl_sni_hostname = "${s3_mirror_hostname}";
+
+    .probe = {
+        .dummy = ${probe_dns_only};
+        .request =
+            "HEAD ${s3_mirror_probe} HTTP/1.1"
+            "Host: ${s3_mirror_hostname}"
+            "User-Agent: Fastly healthcheck (Git commit: ${git_hash})"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = ${probe_interval};
+    }
+}
+
+# Mirror backend for S3 replica
+backend F_mirrorS3Replica {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "${s3_mirror_replica_port}";
+    .host = "${s3_mirror_replica_hostname}";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "${minimum_tls_version}";
+    .ssl_ciphers = "${ssl_ciphers}";
+    .ssl_cert_hostname = "${s3_mirror_replica_hostname}";
+    .ssl_sni_hostname = "${s3_mirror_replica_hostname}";
+
+    .probe = {
+        .dummy = ${probe_dns_only};
+        .request =
+            "HEAD ${s3_mirror_replica_probe} HTTP/1.1"
+            "Host: ${s3_mirror_replica_hostname}"
+            "User-Agent: Fastly healthcheck (Git commit: ${git_hash})"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = ${probe_interval};
+    }
+}
+
+# Mirror backend for GCS
+backend F_mirrorGCS {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "${gcs_mirror_port}";
+    .host = "${gcs_mirror_hostname}";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "${minimum_tls_version}";
+    .ssl_ciphers = "${ssl_ciphers}";
+    .ssl_cert_hostname = "${gcs_mirror_hostname}";
+    .ssl_sni_hostname = "${gcs_mirror_hostname}";
+
+    .probe = {
+        .dummy = ${probe_dns_only};
+        .request =
+            "HEAD ${gcs_mirror_probe} HTTP/1.1"
+            "Host: ${gcs_mirror_hostname}"
+            "User-Agent: Fastly healthcheck (Git commit: ${git_hash})"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 403;
+        .interval = ${probe_interval};
+    }
+}
+%{ endif }
+
+sub vcl_recv {
+  ${indent(2, file("${module_path}/../shared/_boundary_headers.vcl.tftpl"))}
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  ${indent(2, file("${module_path}/../shared/_security_txt_request.vcl"))}
+
+  %{ if contains(["staging", "production"], environment) ~}
+
+  # Common config when failover to mirror buckets
+  if (req.restarts > 0) {
+    set req.url = req.http.original-url;
+
+    # Don't serve from stale for mirrors
+    set req.grace = 0s;
+    set req.http.Fastly-Failover = "1";
+
+    # Replace multiple /
+    set req.url = regsuball(req.url, "([^:])//+", "\1/");
+  }
+
+  # Failover to primary s3 mirror.
+  if (req.restarts == 1) {
+      set req.backend = F_mirrorS3;
+      set req.http.host = "${s3_mirror_hostname}";
+      set req.http.Fastly-Backend-Name = "mirrorS3";
+
+      # Add bucket directory prefix to all the requests
+      set req.url = "/${s3_mirror_prefix}" req.url;
+  }
+
+  # Failover to replica s3 mirror.
+  if (req.restarts == 2) {
+    set req.backend = F_mirrorS3Replica;
+    set req.http.host = "${s3_mirror_replica_hostname}";
+    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/${s3_mirror_replica_prefix}" req.url;
+  }
+
+  # Failover to GCS mirror.
+  if (req.restarts > 2) {
+    set req.backend = F_mirrorGCS;
+    set req.http.host = "${gcs_mirror_hostname}";
+    set req.http.Fastly-Backend-Name = "mirrorGCS";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/${gcs_mirror_prefix}" req.url;
+
+    set req.http.Date = now;
+    set req.http.Authorization = "AWS ${gcs_mirror_access_id}:" digest.hmac_sha1_base64("${gcs_mirror_secret_key}", "GET" LF LF LF now LF "/${gcs_mirror_bucket_name}" req.url.path);
+  }
+  %{ endif ~}
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      error 503 "Error page";
+    }
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = ${default_ttl}s;
+    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      set beresp.ttl = 900s;
+      set beresp.http.Cache-Control = "max-age=900";
+    }
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+  ${indent(2, file("${module_path}/../shared/_security_txt_response.vcl"))}
+
+  # Serve stale from error subroutine as recommended in:
+  # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
+  # The use of `req.restarts == 0` condition is to enforce the restriction
+  # of serving stale only when the backend is the origin.
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
+    /* deliver stale object if it is available */
+    if (stale.exists) {
+      return(deliver_stale);
+    }
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  synthetic {"
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Welcome to Find open data - data.gov.uk</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 0; }
+          header { background: black; }
+          h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+          p { color: black; margin: 30px auto; max-width: 990px; }
+        </style>
+      </head>
+      <body>
+        <header><h1>Find open data - data.gov.uk</h1></header>
+        <p>We're experiencing technical difficulties. Please try again later.</p>
+      </body>
+    </html>"};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -143,10 +143,30 @@ sub vcl_recv {
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
 
+  # Enable real time logging of JA3 signatures for future analysis
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Client-JA3 = tls.client.ja3_md5;
+  }
+
   # Check whether the remote IP address is in the list of blocked IPs
   if (table.lookup(ip_address_denylist, client.ip)) {
     error 403 "Forbidden";
   }
+
+  # Block requests that match a known bad signature
+  if (req.restarts == 0 && fastly.ff.visits_this_service == 0) {
+    if (table.lookup(ja3_signature_denylist, req.http.Client-JA3, "false") == "true") {
+      error 403 "Forbidden";
+    }
+  }
+  %{ if basic_authentication != null }
+  if (! (client.ip ~ allowed_ip_addresses)) {
+    # Check whether the basic auth credentials are correct in integration
+    if (req.http.Authorization != "Basic ${basic_authentication}") {
+      error 401 "Unauthorized";
+    }
+  }
+  %{ endif ~}
 
   # Force SSL.
   if (!req.http.Fastly-SSL) {

--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -187,8 +187,16 @@ sub vcl_recv {
 
   ${indent(2, file("${module_path}/../shared/_security_txt_request.vcl"))}
 
+  # Remove any Google Analytics campaign params
+  set req.url = querystring.globfilter(req.url, "utm_*");
+
   # Sort query params (improve cache hit rate)
   set req.url = querystring.sort(req.url);
+
+  # Remove all query parameters from homepage
+  if (req.url.path == "/") {
+    set req.url = querystring.remove(req.url);
+  }
 
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;

--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -224,7 +224,6 @@ sub vcl_fetch {
   }
 
   if (beresp.http.Cache-Control ~ "private") {
-    set req.http.Fastly-Cachetype = "PRIVATE";
     return (pass);
   }
 
@@ -237,7 +236,6 @@ sub vcl_fetch {
   }
 
   if (beresp.status >= 500 && beresp.status <= 599) {
-    set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
     if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {

--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -152,6 +152,10 @@ sub vcl_recv {
 
   ${indent(2, file("${module_path}/../shared/_security_txt_request.vcl"))}
 
+  # Default backend.
+  set req.backend = F_origin;
+  set req.http.Fastly-Backend-Name = "origin";
+
   %{ if contains(["staging", "production"], environment) ~}
 
   # Save original request url because req.url changes after restarts.

--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -36,107 +36,6 @@ backend F_origin {
 %{ endif ~}
 }
 
-%{ if contains(["staging", "production"], environment) }
-# Mirror backend for S3
-backend F_mirrorS3 {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "${s3_mirror_port}";
-    .host = "${s3_mirror_hostname}";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "${minimum_tls_version}";
-    .ssl_ciphers = "${ssl_ciphers}";
-    .ssl_cert_hostname = "${s3_mirror_hostname}";
-    .ssl_sni_hostname = "${s3_mirror_hostname}";
-
-    .probe = {
-        .dummy = ${probe_dns_only};
-        .request =
-            "HEAD ${s3_mirror_probe} HTTP/1.1"
-            "Host: ${s3_mirror_hostname}"
-            "User-Agent: Fastly healthcheck (Git commit: ${git_hash})"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = ${probe_interval};
-    }
-}
-
-# Mirror backend for S3 replica
-backend F_mirrorS3Replica {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "${s3_mirror_replica_port}";
-    .host = "${s3_mirror_replica_hostname}";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "${minimum_tls_version}";
-    .ssl_ciphers = "${ssl_ciphers}";
-    .ssl_cert_hostname = "${s3_mirror_replica_hostname}";
-    .ssl_sni_hostname = "${s3_mirror_replica_hostname}";
-
-    .probe = {
-        .dummy = ${probe_dns_only};
-        .request =
-            "HEAD ${s3_mirror_replica_probe} HTTP/1.1"
-            "Host: ${s3_mirror_replica_hostname}"
-            "User-Agent: Fastly healthcheck (Git commit: ${git_hash})"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = ${probe_interval};
-    }
-}
-
-# Mirror backend for GCS
-backend F_mirrorGCS {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "${gcs_mirror_port}";
-    .host = "${gcs_mirror_hostname}";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "${minimum_tls_version}";
-    .ssl_ciphers = "${ssl_ciphers}";
-    .ssl_cert_hostname = "${gcs_mirror_hostname}";
-    .ssl_sni_hostname = "${gcs_mirror_hostname}";
-
-    .probe = {
-        .dummy = ${probe_dns_only};
-        .request =
-            "HEAD ${gcs_mirror_probe} HTTP/1.1"
-            "Host: ${gcs_mirror_hostname}"
-            "User-Agent: Fastly healthcheck (Git commit: ${git_hash})"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 403;
-        .interval = ${probe_interval};
-    }
-}
-%{ endif }
-
 sub vcl_recv {
   ${indent(2, file("${module_path}/../shared/_boundary_headers.vcl.tftpl"))}
 
@@ -211,51 +110,6 @@ sub vcl_recv {
   if (req.restarts < 1) {
     set req.http.original-url = req.url;
   }
-
-  # Common config when failover to mirror buckets
-  if (req.restarts > 0) {
-    set req.url = req.http.original-url;
-
-    # Don't serve from stale for mirrors
-    set req.grace = 0s;
-    set req.http.Fastly-Failover = "1";
-
-    # Replace multiple /
-    set req.url = regsuball(req.url, "([^:])//+", "\1/");
-  }
-
-  # Failover to primary s3 mirror.
-  if (req.restarts == 1) {
-      set req.backend = F_mirrorS3;
-      set req.http.host = "${s3_mirror_hostname}";
-      set req.http.Fastly-Backend-Name = "mirrorS3";
-
-      # Add bucket directory prefix to all the requests
-      set req.url = "/${s3_mirror_prefix}" req.url;
-  }
-
-  # Failover to replica s3 mirror.
-  if (req.restarts == 2) {
-    set req.backend = F_mirrorS3Replica;
-    set req.http.host = "${s3_mirror_replica_hostname}";
-    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
-
-    # Add bucket directory prefix to all the requests
-    set req.url = "/${s3_mirror_replica_prefix}" req.url;
-  }
-
-  # Failover to GCS mirror.
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorGCS;
-    set req.http.host = "${gcs_mirror_hostname}";
-    set req.http.Fastly-Backend-Name = "mirrorGCS";
-
-    # Add bucket directory prefix to all the requests
-    set req.url = "/${gcs_mirror_prefix}" req.url;
-
-    set req.http.Date = now;
-    set req.http.Authorization = "AWS ${gcs_mirror_access_id}:" digest.hmac_sha1_base64("${gcs_mirror_secret_key}", "GET" LF LF LF now LF "/${gcs_mirror_bucket_name}" req.url.path);
-  }
   %{ endif ~}
 
 #FASTLY recv
@@ -298,12 +152,9 @@ sub vcl_fetch {
     return (pass);
   }
 
-  if (beresp.status >= 500 && beresp.status <= 599) {
+  if (beresp.status == 500 || beresp.status == 503) {
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
-      error 503 "Error page";
-    }
     return (deliver);
   }
 
@@ -312,16 +163,6 @@ sub vcl_fetch {
   } else {
     # apply the default ttl
     set beresp.ttl = ${default_ttl}s;
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
-      set beresp.ttl = 900s;
-      set beresp.http.Cache-Control = "max-age=900";
-    }
-  }
-
-  # Override default.vcl behaviour of return(pass).
-  if (beresp.http.Set-Cookie) {
-    return (deliver);
   }
 }
 
@@ -360,9 +201,7 @@ sub vcl_error {
   }
 
   # Assume we've hit vcl_error() because the backend is unavailable
-  # for the first two retries. By restarting, vcl_recv() will try
-  # serving from stale before failing over to the mirrors.
-  if (req.restarts < 3) {
+  if (req.restarts < 2) {
     return (restart);
   }
 

--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -140,6 +140,9 @@ backend F_mirrorGCS {
 sub vcl_recv {
   ${indent(2, file("${module_path}/../shared/_boundary_headers.vcl.tftpl"))}
 
+  # Require authentication for PURGE requests
+  set req.http.Fastly-Purge-Requires-Auth = "1";
+
   # Check whether the remote IP address is in the list of blocked IPs
   if (table.lookup(ip_address_denylist, client.ip)) {
     error 403 "Forbidden";

--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -187,6 +187,9 @@ sub vcl_recv {
 
   ${indent(2, file("${module_path}/../shared/_security_txt_request.vcl"))}
 
+  # Sort query params (improve cache hit rate)
+  set req.url = querystring.sort(req.url);
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 

--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -143,6 +143,11 @@ sub vcl_recv {
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
 
+  # Reset proxy headers at the boundary to our network.
+  unset req.http.Client-IP;
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+
   # Enable real time logging of JA3 signatures for future analysis
   if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
     set req.http.Client-JA3 = tls.client.ja3_md5;

--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -154,6 +154,11 @@ sub vcl_recv {
 
   %{ if contains(["staging", "production"], environment) ~}
 
+  # Save original request url because req.url changes after restarts.
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
+  }
+
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -152,6 +152,9 @@ sub vcl_recv {
 
   ${indent(2, file("${module_path}/../shared/_security_txt_request.vcl"))}
 
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
   # Default backend.
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";

--- a/modules/datagovuk/provider.tf
+++ b/modules/datagovuk/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    fastly = {
+      source  = "fastly/fastly"
+    }
+  }
+}

--- a/modules/datagovuk/service.tf
+++ b/modules/datagovuk/service.tf
@@ -93,24 +93,6 @@ resource "fastly_service_vcl" "service" {
     }
   }
 
-  header {
-    name              = "education_standards_url"
-    action            = "set"
-    type              = "request"
-    destination       = "url"
-    source            = "regsub(req.url, \"^/education-standards\", \"\")"
-    request_condition = "education_standards"
-  }
-
-  header {
-    name              = "education_standards_host"
-    action            = "set"
-    type              = "request"
-    destination       = "http.host"
-    source            = "\"dfe-app1.codeenigma.net\""
-    request_condition = "education_standards"
-  }
-
   dynamic "logging_splunk" {
     for_each = {
       for splunk in lookup(var.secrets, "splunk", []) : splunk.name => splunk

--- a/modules/datagovuk/service.tf
+++ b/modules/datagovuk/service.tf
@@ -87,6 +87,24 @@ resource "fastly_service_vcl" "service" {
     }
   }
 
+  header {
+    name              = "education_standards_url"
+    action            = "set"
+    type              = "request"
+    destination       = "url"
+    source            = "regsub(req.url, \"^/education-standards\", \"\")"
+    request_condition = "education_standards"
+  }
+
+  header {
+    name              = "education_standards_host"
+    action            = "set"
+    type              = "request"
+    destination       = "http.host"
+    source            = "\"dfe-app1.codeenigma.net\""
+    request_condition = "education_standards"
+  }
+
   dynamic "logging_s3" {
     for_each = {
       for s3 in lookup(var.secrets, "s3", []) : s3.name => s3

--- a/modules/datagovuk/service.tf
+++ b/modules/datagovuk/service.tf
@@ -1,5 +1,11 @@
 locals {
-  formatted_allowed_ips = [for ip in try(var.secrets["allowed_ip_addresses"], []) : "\"${split("/", ip)[0]}\"/${split("/", ip)[1]}"]
+  ip_allowlist = try(var.secrets["allowed_ip_addresses"], [])
+  allowed_cidrs = [
+    for v in local.ip_allowlist : strcontains(v, "/") ? v : "${v}/32"
+  ]
+  formatted_allowed_ips = [
+    for v in local.allowed_cidrs : format("\"%s\"/%s", split("/", v)[0], split("/", v)[1])
+  ]
   template_values = merge(
     { # some defaults
       origin_port = 443

--- a/modules/datagovuk/service.tf
+++ b/modules/datagovuk/service.tf
@@ -1,0 +1,118 @@
+locals {
+  formatted_allowed_ips = [for ip in try(var.secrets["allowed_ip_addresses"], []) : "\"${split("/", ip)[0]}\"/${split("/", ip)[1]}"]
+  template_values = merge(
+    { # some defaults
+      origin_port = 443
+      minimum_tls_version = "1.2"
+      ssl_ciphers = "ECDHE-RSA-AES256-GCM-SHA384"
+      basic_authentication = null
+      probe_dns_only = true
+
+      # these values are needed even if mirrors aren't enabled in an environment
+      s3_mirror_hostname = null
+      s3_mirror_prefix = null
+      s3_mirror_probe = null
+      s3_mirror_port = 443
+      s3_mirror_replica_hostname = null
+      s3_mirror_replica_prefix = null
+      s3_mirror_replica_probe = null
+      s3_mirror_replica_port = 443
+      gcs_mirror_hostname = null
+      gcs_mirror_access_id = null
+      gcs_mirror_secret_key = null
+      gcs_mirror_bucket_name = null
+      gcs_mirror_prefix = null
+      gcs_mirror_probe = null
+      gcs_mirror_port = 443
+    },
+    { # computed values
+      formatted_allowed_ip_addresses = local.formatted_allowed_ips
+      module_path = "${path.module}"
+    },
+    var.configuration,
+    var.secrets
+  )
+}
+
+resource "fastly_service_vcl" "service" {
+  name    = "${title(local.template_values["environment"])} data.gov.uk"
+  comment = ""
+
+  domain {
+    name = local.template_values["hostname"]
+  }
+
+  vcl {
+    main = true
+    name = "main"
+    content = templatefile("${path.module}/${var.vcl_template_file}", local.template_values)
+  }
+
+  dynamic "condition" {
+    for_each = {
+      for c in lookup(local.template_values, "conditions", []) : c.name => c
+    }
+    iterator = each
+    content {
+      name = each.key
+      priority = each.value.priority
+      statement = each.value.statement
+      type = each.value.type
+    }
+  }
+
+  dynamic "backend" {
+    for_each = {
+      for b in lookup(local.template_values, "backends", []) : b.name => b
+    }
+    iterator = each
+    content {
+      name              = each.key
+      address           = each.value.address
+      use_ssl           = true
+      request_condition = lookup(each.value, "request_condition", "")
+      port              = lookup(each.value, "port", 443)
+      ssl_cert_hostname = each.value.address
+      ssl_sni_hostname  = each.value.address
+      shield            = lookup(each.value, "shield", "london-uk")
+      keepalive_time    = 0
+      healthcheck       = ""
+      max_tls_version   = ""
+      min_tls_version   = ""
+      ssl_ca_cert       = ""
+      ssl_ciphers       = ""
+      ssl_client_cert   = ""
+      ssl_client_key    = ""
+      override_host     = each.value.address
+    }
+  }
+
+  dynamic "logging_s3" {
+    for_each = {
+      for s3 in lookup(var.secrets, "s3", []) : s3.name => s3
+    }
+    iterator = each
+    content {
+      name = each.key
+      bucket_name = each.value.bucket_name
+      domain = each.value.domain
+      path = each.value.path
+      period = each.value.period
+      redundancy = each.value.redundancy
+      s3_access_key = each.value.access_key_id
+      s3_secret_key = each.value.secret_access_key
+      response_condition = lookup(each.value, "response_condition", null)
+
+      format_version = 2
+      message_type = "blank"
+      gzip_level = 9
+      timestamp_format = "%Y-%m-%dT%H:%M:%S.000"
+
+      format = lookup(each.value, "format", chomp(
+        <<-EOT
+        { "client_ip":"%%{json.escape(client.ip)}V", "request_received":"%%{begin:%Y-%m-%d %H:%M:%S.}t%%{time.start.msec_frac}V", "request_received_offset":"%%{begin:%z}t", "method":"%%{json.escape(req.method)}V", "url":"%%{json.escape(req.url)}V", "status":%>s, "request_time":%%{time.elapsed.sec}V.%%{time.elapsed.msec_frac}V, "time_to_generate_response":%%{time.to_first_byte}V, "bytes":%B, "content_type":"%%{json.escape(resp.http.Content-Type)}V", "user_agent":"%%{json.escape(req.http.User-Agent)}V", "fastly_backend":"%%{json.escape(resp.http.Fastly-Backend-Name)}V", "data_centre":"%%{json.escape(server.datacenter)}V", "cache_hit":%%{if(fastly_info.state ~"^(HIT|MISS)(?:-|$)", "true", "false")}V, "cache_response":"%%{regsub(fastly_info.state, "^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*", "\\2\\3") }V", "tls_client_protocol":"%%{json.escape(tls.client.protocol)}V", "tls_client_cipher":"%%{json.escape(tls.client.cipher)}V", "client_ja3":"%%{json.escape(req.http.Client-JA3)}V" }
+        EOT
+      ))
+    }
+  }
+}

--- a/modules/datagovuk/service.tf
+++ b/modules/datagovuk/service.tf
@@ -105,6 +105,34 @@ resource "fastly_service_vcl" "service" {
     request_condition = "education_standards"
   }
 
+  dynamic "logging_splunk" {
+    for_each = {
+      for splunk in lookup(var.secrets, "splunk", []) : splunk.name => splunk
+    }
+    iterator = each
+    content {
+      name           = "Splunk"
+      format_version = 2
+      format = lookup(each.value, "format", chomp(
+        <<-EOT
+        {
+          "time": %%{time.start.sec}V,
+          "host": "Fastly",
+          "index": "${each.value.index}",
+          "source": "%%{server.region}V:%%{server.datacenter}V:%%{server.hostname}V",
+          "sourcetype": "csv:govukcdn_extended",
+          "event": "%h %t \\"%r\\" %>s %b \\"%%{Content-Type}o\\" \\"%%{User-Agent}i\\" \\"%%{Referer}i\\" \\"%%{X-Forwarded-For}i\\" \\"%%{Accept}i\\" %%{fastly_info.state}V"
+        }
+        EOT
+      ))
+      tls_hostname = each.value.hostname
+      token        = each.value.token
+      url          = each.value.url
+      use_tls      = true
+      response_condition = lookup(each.value, "response_condition", null)
+    }
+  }
+
   dynamic "logging_s3" {
     for_each = {
       for s3 in lookup(var.secrets, "s3", []) : s3.name => s3

--- a/modules/datagovuk/variables.tf
+++ b/modules/datagovuk/variables.tf
@@ -1,0 +1,11 @@
+variable "secrets" {
+  default = {}
+}
+
+variable "configuration" {
+  default = {}
+}
+
+variable "vcl_template_file" {
+  default = "datagovuk.vcl.tftpl"
+}


### PR DESCRIPTION
Migrates data.gov.uk fastly services from [govuk-aws](https://github.com/alphagov/govuk-aws/tree/5359b86/terraform/projects/fastly-datagovuk) & [govuk-aws-data](https://github.com/alphagov/govuk-aws-data/tree/b65921e/data/fastly-datagovuk) and aligns it with the other services config. 
Changes to the original config and additions to the standard ones are included in the separate commits.

[Trello 1](https://trello.com/c/MeFx5HpA/3331-migrate-dgu-fastly-services-from-govuk-aws-to-govuk-fastly-5), [Trello 2](https://trello.com/c/U8BJLa3w/3269-get-the-fastly-cdn-logs-for-dgu-into-splunk-5)

### Depends on
- https://github.com/alphagov/govuk-fastly-secrets/pull/9