### PR TITLE
CB/DT - Add AB Tests for SA videos

### DIFF
--- a/ab_tests.yaml
+++ b/ab_tests.yaml
@@ -21,3 +21,19 @@
   - C
   - D
   - Z
+- SAVideoStopSelfEmployed:
+  - A
+  - B
+  - Z
+- SAVideoReturn1:
+  - A
+  - B
+  - z
+- SAVideoPayBill:
+  - A
+  - B
+  - Z
+- ReadyReckonerVideoTest:
+  - A
+  - B
+  - Z

--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -4,12 +4,20 @@ active_ab_tests:
   FindUtrNumberVideoLinks: true
   VertexSearch: true
   HomepagePopularLinksTest: true
+  SAVideoStopSelfEmployed: true
+  SAVideoReturn1: true
+  SAVideoPayBill: true
+  ReadyReckonerVideoTest: true
 ab_test_expiries:
   Example: 86400
   BankHolidaysTest: 86400
   FindUtrNumberVideoLinks: 7776000 # 90 days
   VertexSearch: 86400
   HomepagePopularLinksTest: 172800 # 2 days
+  SAVideoStopSelfEmployed: 86400 # 1 day
+  SAVideoReturn1: 86400 # 1 day
+  SAVideoPayBill: 86400 # 1 day
+  ReadyReckonerVideoTest: 86400 # 1 day
 # AB test percentages
 example_percentages:
   A: 50
@@ -30,4 +38,20 @@ homepagepopularlinkstest_percentages:
   B: 0
   C: 0
   D: 0
+  Z: 100
+savideostopselfemployed_percentages:
+  A: 0
+  B: 0
+  Z: 100
+savideoreturn1_percentages:
+  A: 0
+  B: 0
+  Z: 100
+savideopaybill_percentages:
+  A: 0
+  B: 0
+  Z: 100
+readyreckonervideotest_percentages:
+  A: 0
+  B: 0
   Z: 100


### PR DESCRIPTION
[Trello](https://trello.com/c/GJ5lt8ij/589-set-up-the-next-round-of-a-b-tests)

This PR adds temporary A/B Tests to 3 pages on government-frontend: 
- https://www.gov.uk/stop-being-self-employed
- https://www.gov.uk/pay-self-assessment-tax-bill/pay-weekly-monthly
- https://www.gov.uk/log-in-file-self-assessment-tax-return
