### PR TITLE
Add protocol to athena logs

### DIFF
--- a/modules/www/service.tf
+++ b/modules/www/service.tf
@@ -166,6 +166,7 @@ resource "fastly_service_vcl" "service" {
           "method":"%%{json.escape(req.method)}V",
           "url":"%%{json.escape(req.url)}V",
           "status":%>s,
+          "protocol":"%%{json.escape(req.proto)}V",
           "request_time":%%{time.elapsed.sec}V.%%{time.elapsed.msec_frac}V,
           "time_to_generate_response":%%{time.to_first_byte}V,
           "bytes":%B,

--- a/modules/www/service.tf
+++ b/modules/www/service.tf
@@ -159,7 +159,26 @@ resource "fastly_service_vcl" "service" {
 
       format = try(each.value["format"], chomp(
         <<-EOT
-        { "client_ip":"%%{json.escape(client.ip)}V", "request_received":"%%{begin:%Y-%m-%d %H:%M:%S.}t%%{time.start.msec_frac}V", "request_received_offset":"%%{begin:%z}t", "method":"%%{json.escape(req.method)}V", "url":"%%{json.escape(req.url)}V", "status":%>s, "request_time":%%{time.elapsed.sec}V.%%{time.elapsed.msec_frac}V, "time_to_generate_response":%%{time.to_first_byte}V, "bytes":%B, "content_type":"%%{json.escape(resp.http.Content-Type)}V", "user_agent":"%%{json.escape(req.http.User-Agent)}V", "fastly_backend":"%%{json.escape(resp.http.Fastly-Backend-Name)}V", "data_centre":"%%{json.escape(server.datacenter)}V", "cache_hit":%%{if(fastly_info.state ~"^(HIT|MISS)(?:-|$)", "true", "false")}V, "cache_response":"%%{regsub(fastly_info.state, "^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*", "\\2\\3") }V", "tls_client_protocol":"%%{json.escape(tls.client.protocol)}V", "tls_client_cipher":"%%{json.escape(tls.client.cipher)}V", "client_ja3":"%%{json.escape(req.http.Client-JA3)}V" }
+        {
+          "client_ip":"%%{json.escape(client.ip)}V",
+          "request_received":"%%{begin:%Y-%m-%d %H:%M:%S.}t%%{time.start.msec_frac}V",
+          "request_received_offset":"%%{begin:%z}t",
+          "method":"%%{json.escape(req.method)}V",
+          "url":"%%{json.escape(req.url)}V",
+          "status":%>s,
+          "request_time":%%{time.elapsed.sec}V.%%{time.elapsed.msec_frac}V,
+          "time_to_generate_response":%%{time.to_first_byte}V,
+          "bytes":%B,
+          "content_type":"%%{json.escape(resp.http.Content-Type)}V",
+          "user_agent":"%%{json.escape(req.http.User-Agent)}V",
+          "fastly_backend":"%%{json.escape(resp.http.Fastly-Backend-Name)}V",
+          "data_centre":"%%{json.escape(server.datacenter)}V",
+          "cache_hit":%%{if(fastly_info.state ~"^(HIT|MISS)(?:-|$)", "true", "false")}V,
+          "cache_response":"%%{regsub(fastly_info.state, "^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*", "\\2\\3") }V",
+          "tls_client_protocol":"%%{json.escape(tls.client.protocol)}V",
+          "tls_client_cipher":"%%{json.escape(tls.client.cipher)}V",
+          "client_ja3":"%%{json.escape(req.http.Client-JA3)}V"
+        }
         EOT
       ))
     }


### PR DESCRIPTION
Probaby easier to review the two commits separately - the first one reformats the format string, the second one adds protocol.

There is a follow up PR in govuk-aws to have AWS glue parse this field for use in Athena - https://github.com/alphagov/govuk-aws/pull/1812