### PR TITLE
Enable HTTP/3 for www and assets in all envs

### DIFF
--- a/modules/assets/service.tf
+++ b/modules/assets/service.tf
@@ -36,6 +36,8 @@ resource "fastly_service_vcl" "service" {
   name    = "${title(local.template_values["environment"])} Assets"
   comment = ""
 
+  http3 = true
+
   domain {
     name = local.template_values["hostname"]
   }

--- a/modules/www/service.tf
+++ b/modules/www/service.tf
@@ -50,7 +50,7 @@ resource "fastly_service_vcl" "service" {
   name    = "${title(local.template_values["environment"])} GOV.UK"
   comment = ""
 
-  http3 = var.configuration.environment == "staging"
+  http3 = true
 
   domain {
     name = local.template_values["hostname"]


### PR DESCRIPTION
We've had this running in staging for the last couple of days, where we've done some testing both with local browsers and with Webpagetest.

This has given us reasonable confidence that this will:

a) Not break the website
b) Not make performance significantly worse

[a] - Because HTTP/3 is something that browsers will only upgrade to if they support it, there should be no effect on old browsers. We've tested staging with Firefox / Chrome / Safari / Edge and they all upgrade to HTTP/3 successfully and there aren't any observable issues with the site.

[b] - Synthetic testing hasn't shown the performance improvements were expecting, even for the high packet loss case where we were expecting the biggest performance gains. It doesn't look noticeably worse though, and there's only so far you can get with synthetic testing.

Ultimately, the only way to get a true view of the impact of enabling this is to enable it and observe the effect on real users.

We have Real User Monitoring in place with Speedcurve, and we've added protocol information to our CDN logs.

We've formulated a set of hypotheses we're looking to test. Specifically:

1) We will see a significant fraction of HTTP requests using HTTP/3 in
   the CDN logs (> 50%, since most browsers now support HTTP/3)
2) Comparing median metrics for a day before enabling HTTP/3 with a day
   after enabling HTTP/3, we should see modest improvements in times for
   First Contentful Paint, Largest Contentful Paint, and Page Load
3) We should see more pronounced improvements in these metrics at the
   95% level, and when filtering down to Slow / Very Slow connections

Since we haven't been able to demonstrate significant performance benefits using synthetic testing, we've also considered the possibillity that we won't see improvements in Real User Monitoring. In that case, so long as we don't see detrimental impacts, we would still consider leaving HTTP/3 enabled as there are other potential benefits (such as [Connection Migration](https://datatracker.ietf.org/doc/html/rfc9000#name-connection-migration)).

If we detect detrimental performance impacts of more than about 1%, particularly for users on poor connections we will revert this change and switch back to HTTP/2.