### PR TITLE
Fix format of logging string for assets

### DIFF
--- a/modules/assets/service.tf
+++ b/modules/assets/service.tf
@@ -152,7 +152,7 @@ resource "fastly_service_vcl" "service" {
           "method":"%%{json.escape(req.method)}V",
           "url":"%%{json.escape(req.url)}V",
           "status":%>s,
-          "protocol":"%%{json.escape(req.proto)}",
+          "protocol":"%%{json.escape(req.proto)}V",
           "request_time":%%{time.elapsed.sec}V.%%{time.elapsed.msec_frac}V,
           "time_to_generate_response":%%{time.to_first_byte}V,
           "bytes":%B,


### PR DESCRIPTION
I'd missed off the trailing V which Fastly wants in the format string. This was there in the www config, but not in the assets config. Consequently, we were getting the following error when applying terraform:

    Error: invalid configuration for Fastly Service (...): Failed to parse log format string.