### PR TITLE
Add IPs for new NAT Gateways

### DIFF
--- a/modules/assets/assets.vcl.tftpl
+++ b/modules/assets/assets.vcl.tftpl
@@ -147,9 +147,9 @@ acl purge_ip_allowlist {
   "18.203.108.248";  # AWS Staging NAT gateways
   "18.202.183.143";
   "18.203.90.80";
-  "54.246.115.159";  # EKS Staging NAT gateways
-  "54.220.171.242";
-  "54.228.115.164";
+  "108.128.15.82";   # EKS Staging NAT gateways
+  "46.137.141.50";
+  "18.200.65.72";
 %{ endif ~}
 %{ if environment == "production" ~}
   "18.202.136.43";   # AWS Production NAT gateways
@@ -158,6 +158,9 @@ acl purge_ip_allowlist {
   "63.33.241.191";   # EKS Production NAT gateways
   "52.208.193.230";
   "54.220.6.200";
+  "52.51.83.47";     # EKS Production licensify NAT gateways
+  "46.137.63.103";
+  "34.249.23.204";
 %{ endif ~}
 }
 


### PR DESCRIPTION
As part of the licensify migration we're updating the IPs for our NAT Gateways. The gateways in Staging have already been updated. Keeping the old IPs for production incase we need to revert during the migration. Will remove in subsequent PR.