### PR TITLE
Change multiple variable names in preparation for phase 2 of testing

### DIFF
--- a/ab_tests.yaml
+++ b/ab_tests.yaml
@@ -15,19 +15,15 @@
   - A
   - B
   - Z
-- SAVideoStopSelfEmployed:
+- SAVideoStopSelfEmployed2:
   - A
   - B
   - Z
-- SAVideoReturn1:
+- SAVideoReturn2:
   - A
   - B
   - Z
-- SAVideoPayBill:
-  - A
-  - B
-  - Z
-- ReadyReckonerVideoTest:
+- ReadyReckonerVideoTest2:
   - A
   - B
   - Z

--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -3,19 +3,17 @@ active_ab_tests:
   BankHolidaysTest: true
   FindUtrNumberVideoLinks: true
   VertexSearch: true
-  SAVideoStopSelfEmployed: true
-  SAVideoReturn1: true
-  SAVideoPayBill: true
-  ReadyReckonerVideoTest: true
+  SAVideoStopSelfEmployed2: true
+  SAVideoReturn2: true
+  ReadyReckonerVideoTest2: true
 ab_test_expiries:
   Example: 86400
   BankHolidaysTest: 86400
   FindUtrNumberVideoLinks: 7776000 # 90 days
   VertexSearch: 86400
-  SAVideoStopSelfEmployed: 7776000 # 90 days
-  SAVideoReturn1: 7776000 # 90 days
-  SAVideoPayBill: 7776000 # 90 days
-  ReadyReckonerVideoTest: 7776000 # 90 days
+  SAVideoStopSelfEmployed2: 7776000 # 90 days
+  SAVideoReturn2: 7776000 # 90 days
+  ReadyReckonerVideoTest2: 7776000 # 90 days
 # AB test percentages
 example_percentages:
   A: 50
@@ -31,19 +29,15 @@ vertexsearch_percentages:
   A: 1
   B: 1
   Z: 98
-savideostopselfemployed_percentages:
+savideostopselfemployed2_percentages:
   A: 50
   B: 50
   Z: 0
-savideoreturn1_percentages:
+savideoreturn2_percentages:
   A: 50
   B: 50
   Z: 0
-savideopaybill_percentages:
-  A: 50
-  B: 50
-  Z: 0
-readyreckonervideotest_percentages:
+readyreckonervideotest2_percentages:
   A: 50
   B: 50
   Z: 0


### PR DESCRIPTION
In preparation for Phase 2 of testing, this PR changes the names of the tests involved in phase 2, whilst also removing `sa_video_pay_bill` as its no longer being tested.

[Trello](https://trello.com/c/8n9KMaqo/611-video-a-b-tests-setup-phase-2-a-b-tests)