### PR TITLE
Temporarily removes the datagovuk in integration

### DIFF
--- a/datagovuk.tf
+++ b/datagovuk.tf
@@ -2,14 +2,14 @@ variable "datagovuk_integration" {
   type = string
 }
 
-module "datagovuk-integration" {
-  source = "./modules/datagovuk"
+# module "datagovuk-integration" {
+#   source = "./modules/datagovuk"
 
-  configuration = {
-    environment = "integration"
-    git_hash = var.TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA
-    probe = "/"
-  }
+#   configuration = {
+#     environment = "integration"
+#     git_hash = var.TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA
+#     probe = "/"
+#   }
 
-  secrets = yamldecode(var.datagovuk_integration)
-}
+#   secrets = yamldecode(var.datagovuk_integration)
+# }


### PR DESCRIPTION
This module is failing in fastly. It needs be removed so that other changes can still go ahead whilst it is being fixed.