### PR TITLE
Turn off VertexSearch A/B test

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -26,9 +26,9 @@ findutrnumbervideolinks_percentages:
   B: 50
   Z: 0
 vertexsearch_percentages:
-  A: 10
-  B: 10
-  Z: 80
+  A: 0
+  B: 0
+  Z: 100
 savideostopselfemployed2_percentages:
   A: 50
   B: 50


### PR DESCRIPTION
Temporarily turns off the VertexSearch A/B test.

We've found through testing that some important documents are being removed from the Google index, even though they are being updated in the datastore correctly.

Until this problem is fixed it's not safe to continue with the A/B test as some of the documents affected are for self-assessment and the self-assessment deadline is imminent.