### PR TITLE
Update default backend for DGU

### DIFF
--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -101,7 +101,7 @@ sub vcl_recv {
   set req.max_stale_if_error = 24h;
 
   # Default backend.
-  set req.backend = F_origin;
+  set req.backend = F_cname_find_eks_${environment}_govuk_digital;
   set req.http.Fastly-Backend-Name = "origin";
 
   %{ if contains(["staging", "production"], environment) ~}


### PR DESCRIPTION
To match https://github.com/alphagov/govuk-fastly/blob/main/modules/datagovuk/datagovuk.vcl.tftpl#L1
DGU has only 1 backend. This was missed when updating the name.