### PR TITLE
Remove deny list logic from DGU

### DIFF
--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -47,22 +47,6 @@ sub vcl_recv {
   set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
   set req.http.X-Forwarded-Host = req.http.host;
 
-  # Enable real time logging of JA3 signatures for future analysis
-  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
-    set req.http.Client-JA3 = tls.client.ja3_md5;
-  }
-
-  # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_denylist, client.ip)) {
-    error 403 "Forbidden";
-  }
-
-  # Block requests that match a known bad signature
-  if (req.restarts == 0 && fastly.ff.visits_this_service == 0) {
-    if (table.lookup(ja3_signature_denylist, req.http.Client-JA3, "false") == "true") {
-      error 403 "Forbidden";
-    }
-  }
   %{ if basic_authentication != null }
   if (! (client.ip ~ allowed_ip_addresses)) {
     # Check whether the basic auth credentials are correct in integration


### PR DESCRIPTION
Those are new directives added during a migration to TF Cloud however it requires access to values in
https://github.com/alphagov/govuk-fastly-secrets/blob/main/dictionaries.yaml and caused an error on apply: "Undefined `table ip_address_denylist`"

It can be added once the existing config has been successful ported.