### PR TITLE
Ramp up VertexSearch to 50%

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -26,9 +26,9 @@ findutrnumbervideolinks_percentages:
   B: 50
   Z: 0
 vertexsearch_percentages:
-  A: 0
-  B: 0
-  Z: 100
+  A: 50
+  B: 50
+  Z: 0
 savideostopselfemployed2_percentages:
   A: 50
   B: 50


### PR DESCRIPTION
We're happy that the problem of documents being removed from the new Google search index has been resolved [1], so the A/B test can continue as planned.

[1]: https://github.com/alphagov/govuk-fastly/pull/54