### PR TITLE
Add HTTP Strict-Transport-Security header to unknown URLs

### DIFF
--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -452,6 +452,8 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
+  set resp.http.Strict-Transport-Security = "max-age=31536000; preload";
+
   # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=lax; path=/; max-age=0";


### PR DESCRIPTION
- This sets the HSTS header to the domain within VCL
- Enables consistency throughout the CDN.

Trello: https://trello.com/c/0TgCOgbX/3397-3-configure-fastly-to-always-append-an-hsts-header