### PR TITLE
Rollout data.gov.uk Fastly configuration to production

### DIFF
--- a/datagovuk.tf
+++ b/datagovuk.tf
@@ -33,3 +33,15 @@ module "datagovuk-staging" {
 variable "datagovuk_production" {
   type = string
 }
+
+module "datagovuk-production" {
+  source = "./modules/datagovuk"
+
+  configuration = {
+    environment = "production"
+    git_hash = var.TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA
+    probe = "/"
+  }
+
+  secrets = yamldecode(var.datagovuk_production)
+}

--- a/modules/datagovuk/service.tf
+++ b/modules/datagovuk/service.tf
@@ -86,10 +86,17 @@ resource "fastly_service_vcl" "service" {
     }
   }
 
-  response_object {
-    name              = "${local.template_values["environment"]}.data.gov.uk to www.${local.template_values["environment"]}.data.gov.uk redirect synthetic response"
-    status            = 301
-    request_condition = "${local.template_values["environment"]}.data.gov.uk to www.${local.template_values["environment"]}.data.gov.uk redirect request condition"
+  dynamic "response_object" {
+    for_each = {
+      for c in lookup(local.template_values, "response_objects", []) : c.name => c
+    }
+    iterator = each
+    content {
+      name = each.key
+      status = each.value.status
+      request_condition = each.value.request_condition
+
+    }
   }
 
   request_setting {

--- a/modules/datagovuk/service.tf
+++ b/modules/datagovuk/service.tf
@@ -71,13 +71,19 @@ resource "fastly_service_vcl" "service" {
     }
   }
 
-  header {
-    name               = "${local.template_values["environment"]}.data.gov.uk to www.${local.template_values["environment"]}.data.gov.uk redirect location header"
-    action             = "set"
-    type               = "response"
-    destination        = "http.Location"
-    source             = "\"https://www.${local.template_values["environment"]}.data.gov.uk\" + req.url"
-    response_condition = "${local.template_values["environment"]}.data.gov.uk to www.${local.template_values["environment"]}.data.gov.uk redirect response condition"
+  dynamic "header" {
+    for_each = {
+      for c in lookup(local.template_values, "headers", []) : c.name => c
+    }
+    iterator = each
+    content {
+      name = each.key
+      action = each.value.action
+      type = each.value.type
+      destination = each.value.destination
+      source = each.value.source
+      response_condition = each.value.response_condition
+    }
   }
 
   response_object {


### PR DESCRIPTION
We tested it in integration and staging so now rolling it out to production.

[Plan output](https://app.terraform.io/app/govuk/workspaces/govuk-fastly/runs/run-XqzZurCxTnaLmEJy)

### Depends on
- https://github.com/alphagov/govuk-fastly-secrets/pull/19

#### Diff addressed

- headers
<img width="676" alt="Screenshot 2024-02-07 at 20 32 56" src="https://github.com/alphagov/govuk-fastly/assets/38078064/a30824ee-3f4e-476b-aeef-46fe42a10681">
<img width="819" alt="Screenshot 2024-02-07 at 20 33 15" src="https://github.com/alphagov/govuk-fastly/assets/38078064/f200773e-471c-4830-9365-a729298189ce">

- response objects

<img width="810" alt="Screenshot 2024-02-07 at 20 32 27" src="https://github.com/alphagov/govuk-fastly/assets/38078064/21a89b72-f0db-4cbe-9e8b-051bb8489659">

### To do

- [x] import TF state