### PR TITLE
Update deprecated variables

### DIFF
--- a/modules/assets/assets.vcl.tftpl
+++ b/modules/assets/assets.vcl.tftpl
@@ -190,7 +190,7 @@ sub vcl_recv {
   ${indent(2, file("${module_path}/../shared/_security_txt_request.vcl"))}
 
   # Serve from stale for 24 hours if origin is sick
-  set req.grace = 24h;
+  set req.max_stale_if_error = 24h;
 
   # Default backend.
   set req.backend = F_awsorigin;
@@ -208,7 +208,7 @@ sub vcl_recv {
     set req.url = req.http.original-url;
 
     # Don't serve from stale for mirrors
-    set req.grace = 0s;
+    set req.max_stale_if_error = 0s;
     set req.http.Fastly-Failover = "1";
 
     # Replace multiple /

--- a/modules/assets/assets.vcl.tftpl
+++ b/modules/assets/assets.vcl.tftpl
@@ -270,7 +270,7 @@ sub vcl_fetch {
 
   if (req.restarts == 0) {
     # Keep stale for origin
-    set beresp.grace = 24h;
+    set beresp.stale_if_error = 24h;
   }
 
   if(req.restarts > 0 ) {
@@ -291,7 +291,7 @@ sub vcl_fetch {
 
   if (beresp.status >= 500 && beresp.status <= 599) {
     set beresp.ttl = 1s;
-    set beresp.grace = 5s;
+    set beresp.stale_if_error = 5s;
     if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
       error 503 "Error page";
     }

--- a/modules/bouncer/bouncer.vcl.tftpl
+++ b/modules/bouncer/bouncer.vcl.tftpl
@@ -73,7 +73,7 @@ sub vcl_fetch {
 #FASTLY fetch
 
 
-  set beresp.grace = 86400s;
+  set beresp.stale_if_error = 86400s;
 
   if ((beresp.status == 500 || beresp.status == 503) && req.restarts < 2 && (req.request == "GET" || req.request == "HEAD")) {
     set beresp.saintmode = 5s;
@@ -94,7 +94,7 @@ sub vcl_fetch {
 
   if (beresp.status == 500 || beresp.status == 503) {
     set beresp.ttl = 1s;
-    set beresp.grace = 5s;
+    set beresp.stale_if_error = 5s;
     return (deliver);
   }
 

--- a/modules/bouncer/bouncer.vcl.tftpl
+++ b/modules/bouncer/bouncer.vcl.tftpl
@@ -48,7 +48,7 @@ sub vcl_recv {
   ${indent(2, file("${module_path}/../shared/_security_txt_request.vcl"))}
 
   # Serve from stale for 24 hours if origin is sick
-  set req.grace = 24h;
+  set req.max_stale_if_error = 24h;
 
   # Default backend.
   set req.backend = F_origin0;

--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -365,7 +365,7 @@ sub vcl_fetch {
 
   if (req.restarts == 0) {
     # Keep stale for origin
-    set beresp.grace = 24h;
+    set beresp.stale_if_error = 24h;
   }
 
   if(req.restarts > 0 ) {
@@ -388,7 +388,7 @@ sub vcl_fetch {
 
   if (beresp.status >= 500 && beresp.status <= 599) {
     set beresp.ttl = 1s;
-    set beresp.grace = 5s;
+    set beresp.stale_if_error = 5s;
     if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }

--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -209,7 +209,7 @@ sub vcl_recv {
   set req.url = querystring.globfilter(req.url, "utm_*");
 
   # Serve from stale for 24 hours if origin is sick
-  set req.grace = 24h;
+  set req.max_stale_if_error = 24h;
 
   # Default backend, these details will be overwritten if other backends are
   # chosen
@@ -238,7 +238,7 @@ sub vcl_recv {
     set req.url = req.http.original-url;
 
     # Don't serve from stale for mirrors
-    set req.grace = 0s;
+    set req.max_stale_if_error = 0s;
     set req.http.Fastly-Failover = "1";
 
     # Requests to home page, rewrite to index.html


### PR DESCRIPTION
The following variables were deprecated:
- req-grace: https://www.fastly.com/documentation/reference/vcl/variables/server/req-grace/
- beresp.grace: https://www.fastly.com/documentation/reference/vcl/variables/backend-response/beresp-grace/