### PR TITLE
Ignore query parameters on the homepage

### DIFF
--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -219,6 +219,11 @@ sub vcl_recv {
   # Set a request id header to allow requests to be traced through the stack
   set req.http.GOVUK-Request-Id = uuid.version4();
 
+  if (req.url.path == "/") {
+    # get rid of all query parameters
+    set req.url = querystring.remove(req.url);
+  }
+
   if (req.url.path ~ "^\/alerts(?:\/|$)") {
     # get rid of all query parameters
     set req.url = querystring.remove(req.url);


### PR DESCRIPTION
We don't need to pass query parameters to origin for the homepage. This [used to be on govuk-cdn-config](https://github.com/alphagov/govuk-cdn-config/blob/main/vcl_templates/www.vcl.erb#L255C1-L258C4).

This change improves our ability to cache here, which is important as we get quite spiky traffic on occasion.