### PR TITLE
Allow to configure private extra vcl_recv for www and DGU

### DIFF
--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -72,6 +72,10 @@ sub vcl_recv {
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
   }
+  
+  %{ if private_extra_vcl_recv != "" ~}
+    ${private_extra_vcl_recv}
+  %{ endif ~}
 
   ${indent(2, file("${module_path}/../shared/_security_txt_request.vcl"))}
 

--- a/modules/datagovuk/service.tf
+++ b/modules/datagovuk/service.tf
@@ -30,6 +30,8 @@ locals {
       gcs_mirror_prefix = null
       gcs_mirror_probe = null
       gcs_mirror_port = 443
+
+      private_extra_vcl_recv = ""
     },
     { # computed values
       formatted_allowed_ip_addresses = local.formatted_allowed_ips

--- a/modules/www/service.tf
+++ b/modules/www/service.tf
@@ -31,6 +31,7 @@ locals {
       gcs_mirror_probe           = null
       gcs_mirror_port            = 443
 
+      private_extra_vcl_recv = ""
       ab_tests = []
     },
     { # computed values

--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -199,6 +199,10 @@ sub vcl_recv {
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
   }
+  
+  %{ if private_extra_vcl_recv != "" ~}
+    ${private_extra_vcl_recv}
+  %{ endif ~}
 
   ${indent(2, file("${module_path}/../shared/_security_txt_request.vcl"))}
 


### PR DESCRIPTION
We want to be able to temporarily alter request by adding private (stored in govuk-fastly-secrets) configuration to the subroutine. This may be helpful when handling with incidents.
https://trello.com/c/suUIHnnk/3483-allow-to-configure-private-extra-vclrecv-for-www-and-dgu

### Related PR
- https://github.com/alphagov/govuk-fastly-secrets/pull/23