### PR TITLE
Reject HTTP requests using a non-standard method

### DIFF
--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -199,6 +199,14 @@ sub vcl_recv {
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
   }
+
+  # Temporary if statement to test changes before going to production:
+  %{ if environment == "integration" }
+  # Reject HTTP requests which don't use a standard method
+  if (req.method !~ "^(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH|FASTLYPURGE)") {
+    error 805 "Method not allowed";
+  }
+  %{ endif ~}
   
   %{ if private_extra_vcl_recv != "" ~}
     ${private_extra_vcl_recv}
@@ -537,6 +545,32 @@ sub vcl_error {
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";
+
+    synthetic {"
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>We cannot find the page you're looking for. Please try searching on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
+        </body>
+      </html>"};
+
+    return (deliver);
+  }
+
+  if (obj.status == 805) {
+    set obj.status = 405;
+    set obj.response = "Method not allowed";
+    set obj.http.Fastly-Backend-Name = "force_method_not_allowed";
 
     synthetic {"
       <!DOCTYPE html>


### PR DESCRIPTION
At the moment, request with methods such as DEBUG or PROPFIND will be passed through the CDN and hit the origin, where they'll be rejected by nginx as 501s.

This means we end up with a bunch of 5XX responses in our metrics and logs, even though there's nothing wrong with our system.

    $ curl -w '\n%{http_code}\n' -X DEBUG https://www.gov.uk
    DEBUG method is not supported
    501

This commit rejects these at the CDN, and uses the 405 HTTP status instead of 501 to avoid polluting the CDN metrics with unactionable 5XXs.

I've included all standard HTTP methods, and additionally FASTLYPURGE which is how the non-standard PURGE method appears in VCL[1].

I've also checked which non-standard HTTP methods have appeared in requests so far in May:

    select method, count(*)
    from fastly_logs.govuk_www
    where year=2024 and month=5
    and method not in ('GET','HEAD','POST','PUT','DELETE','CONNECT','OPTIONS','TRACE','PATCH','FASTLYPURGE')
    group by method
    order by count(*) desc

    #	method	_col1
    1	DEBUG	23086
    2	TENB	14458
    3	PROPFIND	7700
    4	HEADX	4029
    5	TRACK	3
    6	BVRPGMCC	1
    7	CET	1
    8	get	1
    9	INDEX	1

... which is enough evidence for me that this won't block anything unintentionally.

Temporarily, I've restricted this to integration so I can test it, instead of just yeeting it into production.

[1]: https://www.fastly.com/documentation/reference/vcl/variables/client-request/req-method/