### PR TITLE
Migrate servicegovuk

### DIFF
--- a/modules/service-domain-redirect/provider.tf
+++ b/modules/service-domain-redirect/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    fastly = {
+      source  = "fastly/fastly"
+    }
+  }
+}

--- a/modules/service-domain-redirect/service.tf
+++ b/modules/service-domain-redirect/service.tf
@@ -1,0 +1,14 @@
+resource "fastly_service_vcl" "service" {
+  name    = "Production service domain redirect"
+  comment = ""
+
+  domain {
+    name = "service.gov.uk"
+  }
+
+  vcl {
+    main    = true
+    name    = "main"
+    content = file("${path.module}/servicegovuk.vcl")
+  }
+}

--- a/modules/service-domain-redirect/servicegovuk.vcl
+++ b/modules/service-domain-redirect/servicegovuk.vcl
@@ -1,0 +1,58 @@
+backend dummy {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .initial = 0;
+    .interval = 365d;
+  }
+}
+
+sub vcl_recv {
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+    error 801 "Force SSL";
+  } else {
+    error 802 "Redirect GOV.UK";
+  }
+
+  return(error);
+}
+
+sub vcl_fetch {
+}
+
+sub vcl_hit {
+}
+
+sub vcl_miss {
+}
+
+sub vcl_deliver {
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    set obj.http.Fastly-Backend-Name = "force_ssl";
+  }
+
+  if (obj.status == 802) {
+    set obj.status = 302;
+    set obj.response = "Moved Temporarily";
+    set obj.http.Location = "https://www.gov.uk";
+    set obj.http.Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload";
+  }
+
+  synthetic {""};
+  return (deliver);
+}
+
+sub vcl_pass {
+}
+
+sub vcl_hash {
+}

--- a/service_domain_redirect.tf
+++ b/service_domain_redirect.tf
@@ -1,0 +1,3 @@
+module "service-domain-redirect-production" {
+  source = "./modules/service-domain-redirect"
+}


### PR DESCRIPTION
The VCL for this service was not migrated over to govuk-fastly. This PR creates the Production service domain redirect Service in Infrastructure as Code.

Trello: https://trello.com/c/r6PSkf8Q/3491-import-production-service-domain-redirect-fastly-service-to-terraform-5