### PR TITLE
Remove NewBrowse A/B test

### DIFF
--- a/ab_tests.yaml
+++ b/ab_tests.yaml
@@ -7,7 +7,3 @@
 - BankHolidaysTest:
   - A
   - B
-- NewBrowse:
-  - A
-  - B
-  - Z

--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -1,11 +1,9 @@
 active_ab_tests:
   Example: true
   BankHolidaysTest: true
-  NewBrowse: true
 ab_test_expiries:
   Example: 86400
   BankHolidaysTest: 86400
-  NewBrowse: 864000 # 10 days
 # AB test percentages
 example_percentages:
   A: 50
@@ -13,7 +11,3 @@ example_percentages:
 bankholidaystest_percentages:
   A: 99
   B: 1
-newbrowse_percentages:
-  A: 50
-  B: 50
-  Z: 0


### PR DESCRIPTION
# Do not action until 28/05 (Tuesday)

## What

Remove NewBrowse A/B test so we have full 7 days at 50%. This is related to the following [PR](https://github.com/alphagov/collections/pull/3630).

## Why

So that we can analyse the results and do the work properly if we were to move to lists

[Trello card](https://trello.com/c/NcutO6EF/2615-remove-a-b-test-and-revert-list-pr-s-m)

## Testing

I've confirmed in the Terraform diff that the changes introduced are as expected. The hash changes are discussed in this thread and they are confirmed to be harmless: https://gds.slack.com/archives/C013F737737/p1716550143651819?thread_ts=1716541278.025089&cid=C013F737737 