### PR TITLE
Handle errors and deliver stale content

### DIFF
--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -125,6 +125,21 @@ sub vcl_recv {
 
 sub vcl_fetch {
 #FASTLY fetch
+  %{ if environment == "integration"}
+    if (beresp.status >= 500 && beresp.status < 600) {
+      
+      if (stale.exists) {
+        return(deliver_stale);
+      }
+      
+      if (req.restarts < 1 && (req.request == "GET" || req.request == "HEAD")) {
+        restart;
+      }
+    }
+
+    set beresp.stale_if_error = 86400s;
+  %{ endif ~}
+
 
   set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
 


### PR DESCRIPTION
Configure serving stale content on error status codes in DGU.

Fastly documentation: https://docs.fastly.com/en/guides/serving-stale-content

Trello: https://trello.com/c/717ASEtA/3544-fix-serving-stale-content-configuration-for-dgu-5