### PR TITLE
Update syntax to target integration

### DIFF
--- a/modules/datagovuk/datagovuk.vcl.tftpl
+++ b/modules/datagovuk/datagovuk.vcl.tftpl
@@ -125,7 +125,7 @@ sub vcl_recv {
 
 sub vcl_fetch {
 #FASTLY fetch
-  %{ if environment == "integration"}
+  %{ if contains(["integration"], environment) ~}
     if (beresp.status >= 500 && beresp.status < 600) {
       
       if (stale.exists) {
@@ -164,7 +164,7 @@ sub vcl_fetch {
     return (pass);
   }
 
-  %{ if environment != "integration"}
+  %{ if contains(["staging", "production"], environment) ~}
     if (beresp.status == 500 || beresp.status == 503) {
       set beresp.ttl = 1s;
       set beresp.stale_if_error = 5s;


### PR DESCRIPTION
The config didn't take effect, it seems like it could be due to the syntax as https://github.com/alphagov/govuk-fastly/blame/75cc8dc4516b40179df30bd14d3cb55b58f5faeb/modules/datagovuk/datagovuk.vcl.tftpl#L109 shows the correct way so a refactor has beeen done.