### PR TITLE
Use the reusable workflow for building images

### DIFF
--- a/.github/workflows/build_diff_gen_image.yaml
+++ b/.github/workflows/build_diff_gen_image.yaml
@@ -1,29 +1,26 @@
 name: Build and push diff generator image
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      gitRef:
+        description: 'Commit, tag or branch name to deploy'
+        required: true
+        type: string
   push:
     branches:
       - main
     paths:
       - "diff-generator/*"
 jobs:
-  build:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-access-key-id: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
-      - uses: aws-actions/amazon-ecr-login@v1
-        id: ecr
-      - name: Build and push image
-        env:
-          DOCKER_BUILDKIT: "1"
-          ECR_REGISTRY: ${{ steps.ecr.outputs.registry }}
-        run: |
-          IMAGE_URI="${ECR_REGISTRY}/govuk-fastly-diff-generator:latest"
-          cd diff-generator
-          docker build . -t "${IMAGE_URI}"
-          docker push "${IMAGE_URI}"
+  build-and-publish-image:
+    name: Build and publish image
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
+    with:
+      gitRef: ${{ inputs.gitRef || github.ref }}
+      dockerfilePath: diff-generator/Dockerfile 
+      context: diff-generator
+      ecrRepositoryName: govuk-fastly-diff-generator
+    permissions:
+      id-token: write
+      contents: read
+      packages: write


### PR DESCRIPTION
This will push the image to ghcr.io instead of directly to ECR.