### PR TITLE
Fix static assets returning 400 error in integration

### DIFF
--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -372,6 +372,9 @@ sub vcl_recv {
     set req.backend = F_staticAssetsS3;
     set req.http.host = "${s3_static_assets_hostname}";
     set req.http.Fastly-Backend-Name = "staticAssetsS3";
+    %{ if basic_authentication != null ~}
+        unset req.http.Authorization;
+    %{ endif ~}
   }
 
   return(lookup);


### PR DESCRIPTION
Description:
- As part of https://github.com/alphagov/govuk-fastly/issues/73 Fastly now talks directly to S3 to serve up static assets
- However in the integration environment the `Authorization: Basic xxx` header is set which Fastly sends along to S3 causing S3 to incorrectly interpret it as an authorization request. This causes a 400 error to return for the static assets
- Following unsets the header so Fastly can correctly send a non-authorized GET request to S3 to retrieve the object and resolve this error