### PR TITLE
Reduce rate limit to 100

### DIFF
--- a/modules/assets/main.tf
+++ b/modules/assets/main.tf
@@ -97,7 +97,7 @@ resource "fastly_service_vcl" "service" {
   rate_limiter {
     name = "rate_limiter_assets_${local.template_values["environment"]}"
 
-    rps_limit            = 500
+    rps_limit            = 100
     window_size          = 10
     penalty_box_duration = 5
 

--- a/modules/bouncer/main.tf
+++ b/modules/bouncer/main.tf
@@ -35,7 +35,7 @@ resource "fastly_service_vcl" "service" {
   rate_limiter {
     name = "rate_limiter_bouncer"
 
-    rps_limit            = 500
+    rps_limit            = 100
     window_size          = 10
     penalty_box_duration = 5
 

--- a/modules/datagovuk/main.tf
+++ b/modules/datagovuk/main.tf
@@ -114,7 +114,7 @@ resource "fastly_service_vcl" "service" {
   rate_limiter {
     name = "rate_limiter_dgu_${local.template_values["environment"]}"
 
-    rps_limit            = 500
+    rps_limit            = 100
     window_size          = 10
     penalty_box_duration = 5
 

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -115,7 +115,7 @@ resource "fastly_service_vcl" "service" {
   rate_limiter {
     name = "rate_limiter_www_${local.template_values["environment"]}"
 
-    rps_limit            = 500
+    rps_limit            = 100
     window_size          = 10
     penalty_box_duration = 5
 


### PR DESCRIPTION
We introducted rate limiting at 500 req/s as a canary to ensure that we didn't effect anything. This lowers the rate limit to a threshold that's more protective.