### PR TITLE
Tag diff-generator image as latest after new image is built

### DIFF
--- a/.github/workflows/build_diff_gen_image.yaml
+++ b/.github/workflows/build_diff_gen_image.yaml
@@ -19,8 +19,24 @@ jobs:
       gitRef: ${{ inputs.gitRef || github.ref }}
       dockerfilePath: diff-generator/Dockerfile 
       context: diff-generator
-      ecrRepositoryName: govuk-fastly-diff-generator
+      imageName: govuk-fastly-diff-generator
     permissions:
       id-token: write
       contents: read
       packages: write
+  tag-latest:
+    name: Tag built image as latest
+    needs: build-and-publish-image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          IMAGE_URI=ghcr.io/${{ github.repository_owner }}/govuk-fastly-diff-generator:${{ needs.build-and-publish-image.outputs.imageTag }}
+          LATEST_URI=ghcr.io/${{ github.repository_owner }}/govuk-fastly-diff-generator:latest
+          docker pull $IMAGE_URI
+          docker tag $IMAGE_URI $LATEST_URI
+          docker push $LATEST_URI


### PR DESCRIPTION
The diff generator lambda is trying to pull the `latest` image from the repository, but the standard build workflow only tags a newly built image with a hash.