### PR TITLE
Fix diff gen image URI in tag-latest job

### DIFF
--- a/.github/workflows/build_diff_gen_image.yaml
+++ b/.github/workflows/build_diff_gen_image.yaml
@@ -35,8 +35,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - run: |
-          IMAGE_URI=ghcr.io/${{ github.repository_owner }}/govuk-fastly-diff-generator:${{ needs.build-and-publish-image.outputs.imageTag }}
-          LATEST_URI=ghcr.io/${{ github.repository_owner }}/govuk-fastly-diff-generator:latest
+          IMAGE_URI=ghcr.io/${{ github.repository_owner }}/govuk/govuk-fastly-diff-generator:${{ needs.build-and-publish-image.outputs.imageTag }}
+          LATEST_URI=ghcr.io/${{ github.repository_owner }}/govuk/govuk-fastly-diff-generator:latest
           docker pull $IMAGE_URI
           docker tag $IMAGE_URI $LATEST_URI
           docker push $LATEST_URI


### PR DESCRIPTION
Image names are prefixed with `govuk/` which I missed in my original PR