### PR TITLE
Add required permissions to tag-latest step

### DIFF
--- a/.github/workflows/build_diff_gen_image.yaml
+++ b/.github/workflows/build_diff_gen_image.yaml
@@ -28,6 +28,9 @@ jobs:
     name: Tag built image as latest
     needs: build-and-publish-image
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: write
     steps:
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION
These permissions are required for the workflow to write to GHCR