### PR TITLE
Ramp up popular tasks ab test 2 days

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -5,7 +5,7 @@ active_ab_tests:
 ab_test_expiries:
   Example: 86400
   BankHolidaysTest: 86400
-  PopularTasks: 43200 # 1/2 day
+  PopularTasks: 172800 # 2 days
 # AB test percentages
 example_percentages:
   A: 50
@@ -14,7 +14,7 @@ bankholidaystest_percentages:
   A: 99
   B: 1
 populartasks_percentages:
-  A: 0
-  B: 0
-  C: 0
-  Z: 100
+  A: 10
+  B: 10
+  C: 10
+  Z: 70


### PR DESCRIPTION
## What

[Trello](https://trello.com/c/q6KtBz1F/2782-ramp-up-popular-tasks-ab-test-10-to-a-b-and-c-for-2-days-preparation-only-do-not-merge-s)

Increased the AB test percentage's so that variants A, B, and C are seen by 10% of users respectively, while the remaining 70% see the Z variant.

Updated the cookie duration for the AB test to 2 days.