### PR TITLE
Ramp up PopularTasks AB Test - 33% to A, B and C

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -5,7 +5,7 @@ active_ab_tests:
 ab_test_expiries:
   Example: 86400
   BankHolidaysTest: 86400
-  PopularTasks: 172800 # 2 days
+  PopularTasks: 7862400 # 91 days/ 3 months avg
 # AB test percentages
 example_percentages:
   A: 50
@@ -14,7 +14,7 @@ bankholidaystest_percentages:
   A: 99
   B: 1
 populartasks_percentages:
-  A: 10
-  B: 10
-  C: 10
-  Z: 70
+  A: 33
+  B: 33
+  C: 33
+  Z: 1


### PR DESCRIPTION
## What

[Trello](https://trello.com/c/Lq1EG1pN/2781-ramp-up-popular-tasks-ab-test-33-to-a-and-33-b-and-33-c-and-1z-preparation-only-do-not-merge-s)

The AB test percentages have been updated so that 33% of users see Variant A, 33% see Variant B, 33% see Variant C, and 1% see Variant Z.

The cookie duration for the AB test has also been extended to 3 months.