### PR TITLE
Reject non-standard HTTP methods at edge

### DIFF
--- a/modules/www/www.vcl.tftpl
+++ b/modules/www/www.vcl.tftpl
@@ -225,6 +225,11 @@ sub vcl_recv {
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
   }
+
+  # Reject unimplemented and non-standard HTTP methods
+  if (req.method !~ "^(GET|HEAD|POST|PUT|DELETE|OPTIONS|PATCH|FASTLYPURGE)") {
+    error 806 "Not Implemented";
+  }
   
   %{ if private_extra_vcl_recv != "" ~}
     ${private_extra_vcl_recv}
@@ -608,6 +613,32 @@ sub vcl_error {
 
     return (deliver);
   }
+
+  if (obj.status == 806) {
+        set obj.status = 501;
+        set obj.response = "Not Implemented";
+        set obj.http.Fastly-Backend-Name = "force_not_implemented";
+
+        synthetic {"
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <title>Welcome to GOV.UK</title>
+              <style>
+                body { font-family: Arial, sans-serif; margin: 0; }
+                header { background: black; }
+                h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+                p { color: black; margin: 30px auto; max-width: 990px; }
+              </style>
+            </head>
+            <body>
+              <header><h1>GOV.UK</h1></header>
+              <p>We cannot find the page you're looking for. Please try searching on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
+            </body>
+          </html>"};
+
+        return (deliver);
+      }
 
   ${indent(2, file("${module_path}/../shared/_security_txt_response.vcl"))}
 


### PR DESCRIPTION
Description:
- Previously non-standard/unimplemented HTTP requests such as `DEBUG` will pass through Fastly and hit the origin where nginx rejects them as 501. See [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/501) as to why this is the appropriate status code to return
- Here Fastly is configured to throw a 501 and return custom HTML. The error code `806` and not `805` is used as the latter is used by `_security_txt_response.vcl` in the [shared VCL](https://github.com/alphagov/govuk-fastly/blob/main/modules/shared/_security_txt_response.vcl)
- `FASTLYPURGE` is how the non-standard `PURGE` method appears in [VCL](https://www.fastly.com/documentation/reference/vcl/variables/client-request/req-method/)
- Tested in integration and staging:

```
curl -w '\n%{http_code}\n' -X DEBUG https://www.staging.publishing.service.gov.uk

        <!DOCTYPE html>
        <html>
          <head>
            <title>Welcome to GOV.UK</title>
            <style>
              body { font-family: Arial, sans-serif; margin: 0; }
              header { background: black; }
              h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
              p { color: black; margin: 30px auto; max-width: 990px; }
            </style>
          </head>
          <body>
501
```

- See [proof of concept here](https://github.com/alphagov/govuk-fastly/pull/78)
- Closes https://github.com/alphagov/govuk-fastly/issues/79