### PR TITLE
Cookie handling for GOV.UK Chat

### DIFF
--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -369,8 +369,18 @@ sub vcl_recv {
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
   #   - sign-in (digital identity) callback
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback|chat/)") {
     unset req.http.Cookie;
+  }
+
+  # Strip cookies for requests to /chat/* that lack a session cookie,
+  # otherwise pass through
+  if (req.url ~ "^/chat/") {
+    if (req.http.cookie:_govuk_chat_session) {
+      return(pass)
+    } else {
+      unset req.http.Cookie;
+    }
   }
 
   if (req.url.path ~ "^\/assets(\/.*)?\z") {
@@ -490,8 +500,13 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback|chat/)") {
     unset beresp.http.Set-Cookie;
+  }
+
+  # We don't want to cache any /chat/* responses that set a cookie
+  if (req.url ~ "^/chat/" && resp.http.Set-Cookie) {
+    return (pass);
   }
 
   # Override default.vcl behaviour of return(pass).


### PR DESCRIPTION
Trello: https://trello.com/c/VZsfdz7x/1739-spike-into-configuring-govuk-infrastructure-so-that-we-can-serve-chat-on-wwwgovuk-chat

GOV.UK Chat is going to be hosted on www.gov.uk/chat and will make use of cookies. Therefore we are going to need to alter the VCL so that cookies are not automatically stripped.

For GOV.UK Chat we want the homepage (GET /chat) to be cached so the regex matches only apply to paths within /chat/*.

If a user has a session cookie for chat we want to always pass the message to the server, if they don't have this session cookie it will be safe to strip to cookies where there may.

I wasn't 100% sure about the behaviour of Fastly caching when cookies are set or not, so to avoid any accidental cachings I've set it to pass any responses received from /chat/* that set a cookie.

These changes will need some testing in integration prior to going live.

/cc @rtrinque to fit into your work