### PR TITLE
Correct s/resp/beresp/

### DIFF
--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -505,7 +505,7 @@ sub vcl_fetch {
   }
 
   # We don't want to cache any /chat/* responses that set a cookie
-  if (req.url ~ "^/chat/" && resp.http.Set-Cookie) {
+  if (req.url ~ "^/chat/" && beresp.http.Set-Cookie) {
     return (pass);
   }
 


### PR DESCRIPTION
I used the incorrect variable name where I should have been referencing backend response.