### PR TITLE
mobile backend - fix cors headers

### DIFF
--- a/mobile-backend/service.tf
+++ b/mobile-backend/service.tf
@@ -56,7 +56,7 @@ resource "fastly_service_vcl" "mobile_backend_service" {
     name        = "Add ttl header"
     action      = "set"
     type        = "response"
-    source      = local.ttl
+    source      = "\"${local.ttl}\""
   }
 
   header {
@@ -64,7 +64,7 @@ resource "fastly_service_vcl" "mobile_backend_service" {
     name        = "Add Cache-Control header"
     action      = "set"
     type        = "response"
-    source      = local.cache_control
+    source      = "\"${local.cache_control}\""
   }
 
   header {
@@ -72,7 +72,7 @@ resource "fastly_service_vcl" "mobile_backend_service" {
     name        = "Add Access-Control-Allow-Origin header"
     action      = "set"
     type        = "response"
-    source      = local.access_control_allow_origin
+    source      = "\"${local.access_control_allow_origin}\""
   }
 
 }


### PR DESCRIPTION
I think when setting header values directly in Terraform, we need to add additional quotes round the values, because Fastly treats the `source` parameter as a variable unless surrounded by quotes (further details about `source` [here](https://docs.fastly.com/en/guides/adding-or-modifying-headers-on-http-requests-and-responses#:~:text=Header%2DName.-,Source,-The%20Source%20field), and specific example for CORS [here](https://docs.fastly.com/en/guides/enabling-cross-origin-resource-sharing)).