### PR TITLE
fixup mobile backend int service to point at s3 correctly

### DIFF
--- a/mobile-backend/service.tf
+++ b/mobile-backend/service.tf
@@ -11,8 +11,7 @@ locals {
     "x-amz-server-side-encryption"
   ]
   # headers to add
-  ttl                         = "300s" # 5 minutes
-  cache_control               = "max-age=300, public, immutable"
+  cache_control               = "max-age=300, public, immutable" # 5 minutes
   access_control_allow_origin = "*"
 }
 
@@ -25,15 +24,17 @@ resource "fastly_service_vcl" "mobile_backend_service" {
   }
 
   backend {
-    name    = "Mobile backend config bucket - ${var.environment}"
-    address = local.origin_hostname
-    port    = 443
+    name          = "Mobile backend config bucket - ${var.environment}"
+    address       = local.origin_hostname
+    override_host = local.origin_hostname
+    port          = 443
 
     connect_timeout       = 1000
     first_byte_timeout    = 15000
     max_conn              = 200
     between_bytes_timeout = 10000
 
+    use_ssl           = true
     ssl_check_cert    = true
     ssl_ciphers       = "ECDHE-RSA-AES256-GCM-SHA384"
     ssl_cert_hostname = local.origin_hostname
@@ -49,14 +50,6 @@ resource "fastly_service_vcl" "mobile_backend_service" {
       action      = "delete"
       type        = "cache"
     }
-  }
-
-  header {
-    destination = "ttl"
-    name        = "Add ttl header"
-    action      = "set"
-    type        = "response"
-    source      = "\"${local.ttl}\""
   }
 
   header {


### PR DESCRIPTION
This PR fixes up a couple of things in the mobile-backend integration service - namely:
* TTL doesn't need to be a header in its own right (and upsets creation of the service)
* We need to set the `override_host` value in order to point at the correct S3 bucket (per guidance [here](https://docs.fastly.com/en/guides/amazon-s3#:~:text=In%20the-,Override%20host,-field%2C%20enter%20an))
* SSL for some reason was not enabled by default, so setting the `use_ssl` param