### PR TITLE
Ensure custom error pages for GOV.UK Chat

### DIFF
--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -230,7 +230,7 @@ sub vcl_recv {
   if (req.method !~ "^(GET|HEAD|POST|PUT|DELETE|OPTIONS|PATCH|FASTLYPURGE)") {
     error 806 "Not Implemented";
   }
-  
+
   %{ if private_extra_vcl_recv != "" ~}
     ${private_extra_vcl_recv}
   %{ endif ~}
@@ -585,6 +585,10 @@ sub vcl_deliver {
 }
 
 sub vcl_error {
+  if (beresp.http.Govuk-Rendered-Error) {
+    return (deliver);
+  }
+
   if (obj.status == 801) {
     set obj.status = 301;
     set obj.response = "Moved Permanently";


### PR DESCRIPTION
## Description

We've added custom error pages for our 500 and 503 errors. This updates the vcl_error subroutine to serve these custom error pages when the `Govuk-Rendered-Error` header is set.

Our application returns a 503 status code when public access is toggled off. I'm unsure if there are other cases where we may receive a 503 status code and Roch thinks that the load balancer will return a 500 status if the application is down.

To ensure that we don't accidentally move to the deliver subroutine when a 500 or 503 is returned without our custom error page we came up with the idea of adding a header which indicates that we want to serve the page from the application.

This change adds a check for the `Govuk-Rendered-Error` header in the vcl_error subroutine. If present it moves to the deliver subroutine which serves the custom error page.

## PR on Chat which adds the header

https://github.com/alphagov/govuk-chat/pull/702

## Trello card

https://trello.com/c/5Mc3o62p/1927-temporary-offline-experience-messes-with-cdn-config