### PR TITLE
Add a disable_chat bool to disable the GOV.UK chat service

### DIFF
--- a/www/service.tf
+++ b/www/service.tf
@@ -19,6 +19,7 @@ locals {
       minimum_tls_version  = "1.2"
       ssl_ciphers          = "ECDHE-RSA-AES256-GCM-SHA384"
       basic_authentication = null
+      disable_chat         = false
 
       s3_static_assets_port     = 443
       s3_static_assets_hostname = null

--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -373,6 +373,13 @@ sub vcl_recv {
     unset req.http.Cookie;
   }
 
+%{ if disable_chat == true ~}
+  # Chat app is disabled
+  if (req.url ~ "^/chat/") {
+    error 503 "Service unavailable";
+  }
+%{ endif ~}
+
   # Strip cookies for requests to /chat/* that lack a session cookie,
   # otherwise pass through
   if (req.url ~ "^/chat/") {


### PR DESCRIPTION
In case of an emergency we want a way to disable the service at the edge.