### PR TITLE
Add `SearchAutocomplete` AB test

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -2,10 +2,12 @@ active_ab_tests:
   Example: true
   BankHolidaysTest: true
   PopularTasks: true
+  SearchAutocomplete: true
 ab_test_expiries:
   Example: 86400
   BankHolidaysTest: 86400
   PopularTasks: 7862400 # 91 days/ 3 months avg
+  SearchAutocomplete: 86400
 # AB test percentages
 example_percentages:
   A: 50
@@ -18,3 +20,7 @@ populartasks_percentages:
   B: 33
   C: 33
   Z: 1
+searchautocomplete_percentages:
+  A: 0 # Autocomplete off (control)
+  B: 0 # Autocomplete on (experiment)
+  Z: 100 # Baseline

--- a/www/ab_tests.yaml
+++ b/www/ab_tests.yaml
@@ -12,3 +12,7 @@
   - B
   - C
   - Z
+- SearchAutocomplete:
+  - A # Autocomplete off (control)
+  - B # Autocomplete on (experiment)
+  - Z # Baseline


### PR DESCRIPTION
We will shortly be testing a new autocomplete component for site search.

This sets up the AB test with an initial 0/0/100 split (all baseline/"Z"), to allow us to get the rest of the AB test plumbing into place and use it as a mini feature flag to start testing the functionality on production.