### PR TITLE
Add pass for chat HEAD request routes

### DIFF
--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -385,6 +385,10 @@ sub vcl_recv {
   if (req.url ~ "^/chat/") {
     if (req.http.cookie:_govuk_chat_session) {
       return(pass);
+    # These endpoints make use of HEAD requests and we don't want these
+    # to be converted to GET requests (https://www.fastly.com/documentation/reference/vcl/subroutines/recv/)
+    } elsif (req.url ~ "^/chat/(sign-in|unsubscribe)" && req.request == "HEAD") {
+      return(pass);
     } else {
       unset req.http.Cookie;
     }


### PR DESCRIPTION
GOV.UK Chat makes use of one-time magic links. These magic links are vulnerable to mail clients sending a HEAD request. Our application code can then reject the HEAD request.

However a problem is that Fastly will convert these HEAD requests into GET requests and our application doesn't know that they are HEAD requests and thus treats the link as being used.