### PR TITLE
Start autocomplete AB test

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -5,7 +5,7 @@ active_ab_tests:
 ab_test_expiries:
   Example: 86400
   BankHolidaysTest: 86400
-  SearchAutocomplete: 86400
+  SearchAutocomplete: 7776000 # 90 days
 # AB test percentages
 example_percentages:
   A: 50
@@ -14,6 +14,6 @@ bankholidaystest_percentages:
   A: 99
   B: 1
 searchautocomplete_percentages:
-  A: 0 # Autocomplete off (control)
-  B: 0 # Autocomplete on (experiment)
-  Z: 100 # Baseline
+  A: 5 # Autocomplete off
+  B: 5 # Autocomplete on
+  Z: 90 # Autocomplete off (control)


### PR DESCRIPTION
Initially this will direct 5% of traffic to the experiment variant (B).
Also extends expiry to 90 days.