### PR TITLE
Autocomplete AB test: Dial up to 50/50

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -14,6 +14,6 @@ bankholidaystest_percentages:
   A: 99
   B: 1
 searchautocomplete_percentages:
-  A: 5 # Autocomplete off
-  B: 5 # Autocomplete on
-  Z: 90 # Autocomplete off (control)
+  A: 50 # Autocomplete off
+  B: 50 # Autocomplete on
+  Z: 0 # Autocomplete off (control)


### PR DESCRIPTION
This will only leave users who opted out of analytics in Z.