### PR TITLE
Add cache state to Server-Timing header

### DIFF
--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -544,6 +544,12 @@ sub vcl_miss {
 sub vcl_deliver {
   set resp.http.Strict-Transport-Security = "max-age=31536000; preload";
 
+  if (fastly_info.state ~ "^HIT") {
+    set resp.http.Server-Timing:cacheHit = "";
+  } else if (fastly_info.state ~ "^MISS") {
+    set resp.http.Server-Timing:cacheMiss = "";
+  }
+
   # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=lax; path=/; max-age=0";


### PR DESCRIPTION
This will allow us to read whether or not a page was cached using JavaScript, which will allow us to report the value to our Real-User-Monitoring (RUM) system.

Having the cache status in the RUM system will allow us to get a better view of how much the cache improves web performance, and a more realistic view of how long cache misses take.

The [Server-Timing] header "communicates one or more performance metrics about the request-response cycle to the user agent". It can have arbitrary names, but only dur and desc as values. We could do:

    Server-Timing: cache;desc="HIT"

... but that feels like a misuse of the description field. So instead we're doing:

    Server-Timing: cacheHit

or

    Server-Timing: cacheMiss

There're no meaningful values we can give for duration or description, so we're not including those.

This can be accessed from JavaScript as follows:

    const navigation = performance.getEntriesByType('navigation')[0]
    const serverTiming = navigation.serverTiming.map(st => st.name)
    // => ['cacheHit']

The [fastly_info.state] variable has a fair bit of detail about the state of the request. We only care about whether it was a HIT / MISS though, and exposing any more information might pose a bit of a security issue. Users can already tell whether a response was a cache hit or miss from the X-Cache header, but the other detail isn't available.

[Server-Timing]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing
[fastly_info.state]: https://www.fastly.com/documentation/reference/vcl/variables/miscellaneous/fastly-info-state/