### PR TITLE
Set rps limit to 10 for bank-holidays.json rate limiter

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -13,4 +13,4 @@ bankholidaystest_percentages:
   B: 1
 # Dictionary for /bank-holidays.json rate limiter
 bankholidaysjson_ratelimiter:
-  /bank-holidays.json: 'Bank Holidays JSON'
+  '/bank-holidays.json': 'Bank Holidays JSON'

--- a/www/service.tf
+++ b/www/service.tf
@@ -143,7 +143,7 @@ resource "fastly_service_vcl" "service" {
   rate_limiter {
     name = "rate_limiter_bank_holidays_json"
 
-    rps_limit            = 5
+    rps_limit            = 10
     window_size          = 10
     penalty_box_duration = 1
 

--- a/www/service.tf
+++ b/www/service.tf
@@ -149,7 +149,7 @@ resource "fastly_service_vcl" "service" {
 
     uri_dictionary_name = "bankholidaysjson_ratelimiter"
 
-    client_key   = "req.http.Fastly-Client-IP"
+    client_key   = "client.ip"
     http_methods = "GET,PUT,TRACE,POST,HEAD,DELETE,PATCH,OPTIONS"
 
     action = "response"


### PR DESCRIPTION
The minimum rps for fastly rate limiters is 10, so we will have to use that