### PR TITLE
Remove VCL conditionals for GOV.UK Chat

### DIFF
--- a/www/service.tf
+++ b/www/service.tf
@@ -19,8 +19,6 @@ locals {
       minimum_tls_version  = "1.2"
       ssl_ciphers          = "ECDHE-RSA-AES256-GCM-SHA384"
       basic_authentication = null
-      disable_chat         = false
-      chat_path_regex      = "^/chat(/.*)?$" # matches /chat and /chat/*
 
       s3_static_assets_port     = 443
       s3_static_assets_hostname = null

--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -363,20 +363,6 @@ sub vcl_recv {
 
   ${indent(2, ab_tests_rendered)}
 
-  # Strip cookies for requests to GOV.UK Chat URLs that lack a session cookie,
-  # otherwise pass through
-  if (req.url.path ~ "${chat_path_regex}") {
-    if (req.http.cookie:_govuk_chat_session) {
-      return(pass);
-    # These endpoints make use of HEAD requests and we don't want these
-    # to be converted to GET requests (https://www.fastly.com/documentation/reference/vcl/subroutines/recv/)
-    } elsif (req.url ~ "^/chat/(sign-in|unsubscribe)" && req.request == "HEAD") {
-      return(pass);
-    } else {
-      unset req.http.Cookie;
-    }
-  }
-
   # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
   # For simplicity and security most applications should not use cookies.
   # With the exception of:
@@ -386,13 +372,6 @@ sub vcl_recv {
   if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback/)") {
     unset req.http.Cookie;
   }
-
-%{ if disable_chat == true ~}
-  # Chat app is disabled
-  if (req.url.path ~ "${chat_path_regex}") {
-    error 503 "Service unavailable";
-  }
-%{ endif ~}
 
   if (req.url.path ~ "^\/assets(\/.*)?\z") {
     set req.backend = F_staticAssetsS3;
@@ -508,11 +487,6 @@ sub vcl_fetch {
       unset beresp.http.x-amz-version-id;
       unset beresp.http.x-amz-server-side-encryption;
     }
-  }
-
-  # We don't want to cache any GOV.UK Chat responses that set a cookie
-  if (req.url.path ~ "${chat_path_regex}" && beresp.http.Set-Cookie) {
-    return (pass);
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}


### PR DESCRIPTION
Trello: https://trello.com/c/evNZhxxc/2285-set-up-410-page-for-govuk-chat-to-be-served-by-govuk

Opened as a draft until I complete the changes to helm charts

GOV.UK Chat is being deintegrated from www.gov.uk now that the private beta has concluded. This removes the additional VCL configuration from Fastly.