### PR TITLE
Add `SearchFreshnessBoost` AB test

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -1,9 +1,11 @@
 active_ab_tests:
   Example: true
   BankHolidaysTest: true
+  SearchFreshnessBoost: true
 ab_test_expiries:
   Example: 86400
   BankHolidaysTest: 86400
+  SearchFreshnessBoost: 86400
 # AB test percentages
 example_percentages:
   A: 50
@@ -11,6 +13,10 @@ example_percentages:
 bankholidaystest_percentages:
   A: 99
   B: 1
+searchfreshnessboost_percentages:
+  A: 5
+  B: 5
+  Z: 90
 # Dictionary for /bank-holidays.json rate limiter
 bankholidaysjson_ratelimiter:
   '/bank-holidays.json': 'Bank Holidays JSON'

--- a/www/ab_tests.yaml
+++ b/www/ab_tests.yaml
@@ -7,3 +7,7 @@
 - BankHolidaysTest:
   - A
   - B
+- SearchFreshnessBoost:
+  - A
+  - B
+  - Z


### PR DESCRIPTION
This will be used in Finder Frontend to allow us to AB test some config changes in Vertex AI Search.

Initially this has a 5/5/90 split to make sure nothing untoward happens,
we'll dial this up to 50/50/0 shortly.


see https://trello.com/c/7vbzHU0K/774-set-up-ab-test