### PR TITLE
Start full search freshness boost AB test

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -14,9 +14,9 @@ bankholidaystest_percentages:
   A: 99
   B: 1
 searchfreshnessboost_percentages:
-  A: 5
-  B: 5
-  Z: 90
+  A: 50
+  B: 50
+  Z: 0
 # Dictionary for /bank-holidays.json rate limiter
 bankholidaysjson_ratelimiter:
   '/bank-holidays.json': 'Bank Holidays JSON'


### PR DESCRIPTION
This dials the AB test up to 50/50, having successfully verified it at a lower initial split.