### PR TITLE
Add configuration for GraphQL A/B test

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -1,10 +1,16 @@
 active_ab_tests:
   Example: true
   BankHolidaysTest: true
+  GraphQLMinistersIndex: true
+  GraphQLNewsArticles: true
+  GraphQLRoles: true
   SearchFreshnessBoost: true
 ab_test_expiries:
   Example: 86400
   BankHolidaysTest: 86400
+  GraphQLMinistersIndex: 86400
+  GraphQLNewsArticles: 86400
+  GraphQLRoles: 86400
   SearchFreshnessBoost: 86400
 # AB test percentages
 example_percentages:
@@ -13,6 +19,18 @@ example_percentages:
 bankholidaystest_percentages:
   A: 99
   B: 1
+graphql_ministers_index_percentages:
+  A: 0
+  B: 0
+  Z: 100
+graphql_news_articles_percentages:
+  A: 0
+  B: 0
+  Z: 100
+graphql_roles_percentages:
+  A: 0
+  B: 0
+  Z: 100
 searchfreshnessboost_percentages:
   A: 50
   B: 50

--- a/www/ab_tests.yaml
+++ b/www/ab_tests.yaml
@@ -7,6 +7,18 @@
 - BankHolidaysTest:
   - A
   - B
+- GraphQLMinistersIndex:
+  - A
+  - B
+  - Z
+- GraphQLNewsArticles:
+  - A
+  - B
+  - Z
+- GraphQLRoles:
+  - A
+  - B
+  - Z
 - SearchFreshnessBoost:
   - A
   - B


### PR DESCRIPTION
This will allow us to vary traffic between Content Store and GraphQL.

The tests are currently enabled but sending 100% of traffic to Content Store.  We will vary the traffic mix in later PRs.

[Trello card](https://trello.com/c/stxnESVI)