### PR TITLE
Fix names for A/B test percentages

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -19,15 +19,15 @@ example_percentages:
 bankholidaystest_percentages:
   A: 99
   B: 1
-graphql_ministers_index_percentages:
+graphqlministersindex_percentages:
   A: 0
   B: 0
   Z: 100
-graphql_news_articles_percentages:
+graphqlnewsarticles_percentages:
   A: 0
   B: 0
   Z: 100
-graphql_roles_percentages:
+graphqlroles_percentages:
   A: 0
   B: 0
   Z: 100


### PR DESCRIPTION
The dictionaries defining the A/B test percentages were incorrectly named in a3a52acd0173b22cad6ee1650edb312aacd1b609.

Updating them to remove the underscores.

[Trello card](https://trello.com/c/stxnESVI)