### PR TITLE
End `SearchFreshnessBoost` AB test for now

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -38,9 +38,9 @@ graphqlworldindex_percentages:
   B: 0
   Z: 100
 searchfreshnessboost_percentages:
-  A: 50
-  B: 50
-  Z: 0
+  A: 0
+  B: 0
+  Z: 100
 # Dictionary for /bank-holidays.json rate limiter
 bankholidaysjson_ratelimiter:
   '/bank-holidays.json': 'Bank Holidays JSON'


### PR DESCRIPTION
This suspends the test by directing all traffic to `Z`, but keeping the test around as we may be restarting it soon with a different configuration.