### PR TITLE
Send 1% of traffic to ministers index A/B test variant

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -22,9 +22,9 @@ bankholidaystest_percentages:
   A: 99
   B: 1
 graphqlministersindex_percentages:
-  A: 0
-  B: 0
-  Z: 100
+  A: 99
+  B: 1
+  Z: 0
 graphqlnewsarticles_percentages:
   A: 0
   B: 0


### PR DESCRIPTION
This will add the header for the ministers index A/B variant to 1% of all overall traffic, therefore meaning the ministers index page will start receiving a very low amount of traffic.

We will monitor this and increase the traffic level when we are happy the page is performing correctly.

[Trello card](https://trello.com/c/V0SMNIAT)