### PR TITLE
Send 50% of traffic to ministers index A/B test variant

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -22,8 +22,8 @@ bankholidaystest_percentages:
   A: 99
   B: 1
 graphqlministersindex_percentages:
-  A: 99
-  B: 1
+  A: 50
+  B: 50
   Z: 0
 graphqlnewsarticles_percentages:
   A: 0


### PR DESCRIPTION
We have seen almost no traffic hit the ministers index page with a 1% level of traffic. Therefore increasing to 50% to make sure we actually see some traffic visiting the page.

[Trello card](https://trello.com/c/V0SMNIAT)