### PR TITLE
Add roles to GraphQL A/B test

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -30,9 +30,9 @@ graphqlnewsarticles_percentages:
   B: 0
   Z: 100
 graphqlroles_percentages:
-  A: 0
-  B: 0
-  Z: 100
+  A: 50
+  B: 50
+  Z: 0
 graphqlworldindex_percentages:
   A: 50
   B: 50


### PR DESCRIPTION
This was reverted in d879d9b1a3d086a0e415f3dab05e008593f03a5d, as we had identified some differences between the GraphQL and Content Store rendered versions of the pages.

We are now happy they match, so can reintroduce them into the GraphQL A/B test.

[Trello card](https://trello.com/c/5ggdXNEB)