### PR TITLE
Output Fastly log S3 ARN for use by Infra Repo

### DIFF
--- a/logs/main.tf
+++ b/logs/main.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "fastly_logs" {
 resource "aws_s3_bucket_logging" "fastly_logs" {
   bucket = aws_s3_bucket.fastly_logs.id
 
-  target_bucket = data.tfe_outputs.vpc.nonsensitive_values.aws_logging_bucket_id
+  target_bucket = data.tfe_outputs.logging.nonsensitive_values.aws_logging_bucket_id
   target_prefix = "s3/govuk-${var.govuk_environment}-fastly-logs/"
 }
 
@@ -675,7 +675,7 @@ resource "aws_s3_bucket" "fastly_logs_monitoring" {
 resource "aws_s3_bucket_logging" "fastly_logs_monitoring" {
   bucket = aws_s3_bucket.fastly_logs_monitoring.id
 
-  target_bucket = data.tfe_outputs.vpc.nonsensitive_values.aws_logging_bucket_id
+  target_bucket = data.tfe_outputs.logging.nonsensitive_values.aws_logging_bucket_id
   target_prefix = "s3/govuk-${var.govuk_environment}-fastly-logs-monitoring/"
 }
 
@@ -764,7 +764,7 @@ resource "aws_s3_bucket" "transition_fastly_logs" {
 resource "aws_s3_bucket_logging" "transition_fastly_logs" {
   bucket = aws_s3_bucket.transition_fastly_logs.id
 
-  target_bucket = data.tfe_outputs.vpc.nonsensitive_values.aws_logging_bucket_id
+  target_bucket = data.tfe_outputs.logging.nonsensitive_values.aws_logging_bucket_id
   target_prefix = "s3/govuk-${var.govuk_environment}-transition-fastly-logs/"
 }
 

--- a/logs/outputs.tf
+++ b/logs/outputs.tf
@@ -1,0 +1,4 @@
+output "govuk_fastly_logs_s3_bucket_arn" {
+  value       = aws_s3_bucket.fastly_logs.arn
+  description = "The ARN of the S3 bucket where Fastly logs are stored."
+}

--- a/logs/remote.tf
+++ b/logs/remote.tf
@@ -1,6 +1,6 @@
 data "aws_caller_identity" "current" {}
 
-data "tfe_outputs" "vpc" {
+data "tfe_outputs" "logging" {
   organization = "govuk"
-  workspace    = "vpc-${var.govuk_environment}"
+  workspace    = "logging-${var.govuk_environment}"
 }


### PR DESCRIPTION
## What?
This outputs the Fastly Logs S3 Bucket ARN so we can pick this up in `govuk-infrastructure` for the new IAM Role that we are switching to.