### PR TITLE
Fix Lambda Python Runtime Drift

### DIFF
--- a/logs/main.tf
+++ b/logs/main.tf
@@ -830,7 +830,7 @@ resource "aws_lambda_function" "transition_executor" {
   function_name = "govuk-${var.govuk_environment}-transition"
   role          = aws_iam_role.transition_executor.arn
   handler       = "main.lambda_handler"
-  runtime       = "python3.8"
+  runtime       = "python3.13"
 
   environment {
     variables = {


### PR DESCRIPTION
## What?
This changes the Python runtime from 3.8 to 3.13 which Terraform is trying to revert.