### PR TITLE
Add iam_role_arn setting to Fastly VCL configs

### DIFF
--- a/assets/service.tf
+++ b/assets/service.tf
@@ -160,8 +160,9 @@ resource "fastly_service_vcl" "service" {
       path               = each.value.path
       period             = each.value.period
       redundancy         = each.value.redundancy
-      s3_access_key      = each.value.access_key_id
-      s3_secret_key      = each.value.secret_access_key
+      s3_iam_role        = try(each.value.iam_role_arn, null)
+      s3_access_key      = try(each.value.access_key_id, null)
+      s3_secret_key      = try(each.value.secret_access_key, null)
       response_condition = lookup(each.value, "response_condition", null)
 
       format_version   = 2

--- a/bouncer/service.tf
+++ b/bouncer/service.tf
@@ -64,8 +64,9 @@ resource "fastly_service_vcl" "service" {
       path               = each.value.path
       period             = each.value.period
       redundancy         = each.value.redundancy
-      s3_access_key      = each.value.access_key_id
-      s3_secret_key      = each.value.secret_access_key
+      s3_iam_role        = try(each.value.iam_role_arn, null)
+      s3_access_key      = try(each.value.access_key_id, null)
+      s3_secret_key      = try(each.value.secret_access_key, null)
       response_condition = lookup(each.value, "response_condition", null)
 
       format_version   = 2

--- a/datagovuk/service.tf
+++ b/datagovuk/service.tf
@@ -174,8 +174,9 @@ resource "fastly_service_vcl" "service" {
       path               = each.value.path
       period             = each.value.period
       redundancy         = each.value.redundancy
-      s3_access_key      = each.value.access_key_id
-      s3_secret_key      = each.value.secret_access_key
+      s3_iam_role        = try(each.value.iam_role_arn, null)
+      s3_access_key      = try(each.value.access_key_id, null)
+      s3_secret_key      = try(each.value.secret_access_key, null)
       response_condition = lookup(each.value, "response_condition", null)
 
       format_version   = 2

--- a/www/service.tf
+++ b/www/service.tf
@@ -199,8 +199,9 @@ resource "fastly_service_vcl" "service" {
       path               = each.value.path
       period             = each.value.period
       redundancy         = each.value.redundancy
-      s3_access_key      = each.value.access_key_id
-      s3_secret_key      = each.value.secret_access_key
+      s3_iam_role        = try(each.value.iam_role_arn, null)
+      s3_access_key      = try(each.value.access_key_id, null)
+      s3_secret_key      = try(each.value.secret_access_key, null)
       response_condition = try(each.value["response_condition"], null)
 
       format_version   = 2


### PR DESCRIPTION
## What?
This adds the ability to set an iam_role_arn setting for our VCL configurations, allowing us to choose between legacy IAM Access Keys and specifying IAM Role ARNs to assume instead.

There will be a follow-up PR to set this value later.