### PR TITLE
Enable the DDOS protection product

### DIFF
--- a/assets/service.tf
+++ b/assets/service.tf
@@ -50,6 +50,13 @@ resource "fastly_service_vcl" "service" {
     name = local.template_values["hostname"]
   }
 
+  product_enablement {
+    ddos_protection {
+      enabled = true
+      mode    = "log"
+    }
+  }
+
   vcl {
     main    = true
     name    = "main"

--- a/bouncer/service.tf
+++ b/bouncer/service.tf
@@ -25,6 +25,13 @@ resource "fastly_service_vcl" "service" {
     }
   }
 
+  product_enablement {
+    ddos_protection {
+      enabled = true
+      mode    = "log"
+    }
+  }
+
   vcl {
     main = true
     name = "main"

--- a/datagovuk/service.tf
+++ b/datagovuk/service.tf
@@ -59,6 +59,13 @@ resource "fastly_service_vcl" "service" {
     }
   }
 
+  product_enablement {
+    ddos_protection {
+      enabled = true
+      mode    = "log"
+    }
+  }
+
   vcl {
     main    = true
     name    = "main"

--- a/mobile-backend/service.tf
+++ b/mobile-backend/service.tf
@@ -23,6 +23,13 @@ resource "fastly_service_vcl" "mobile_backend_service" {
     name = local.hostname
   }
 
+  product_enablement {
+    ddos_protection {
+      enabled = true
+      mode    = "log"
+    }
+  }
+
   backend {
     name          = "Mobile backend config bucket - ${var.environment}"
     address       = local.origin_hostname

--- a/service-domain-redirect/service.tf
+++ b/service-domain-redirect/service.tf
@@ -6,6 +6,13 @@ resource "fastly_service_vcl" "service" {
     name = "service.gov.uk"
   }
 
+  product_enablement {
+    ddos_protection {
+      enabled = true
+      mode    = "log"
+    }
+  }
+
   vcl {
     main    = true
     name    = "main"

--- a/tld-redirect/service.tf
+++ b/tld-redirect/service.tf
@@ -10,6 +10,13 @@ resource "fastly_service_vcl" "service" {
     name = local.secrets["domain"]
   }
 
+  product_enablement {
+    ddos_protection {
+      enabled = true
+      mode    = "log"
+    }
+  }
+
   vcl {
     main    = true
     name    = "main"

--- a/www/service.tf
+++ b/www/service.tf
@@ -68,6 +68,13 @@ resource "fastly_service_vcl" "service" {
     name = local.template_values["hostname"]
   }
 
+  product_enablement {
+    ddos_protection {
+      enabled = true
+      mode    = "log"
+    }
+  }
+
   vcl {
     main    = true
     name    = "main"


### PR DESCRIPTION
We can enable [DDOS protection](https://www.fastly.com/documentation/guides/security/ddos-protection/about-ddos-protection/) on our services now. We'll begin by using `log` mode to evaluate the likely effect.

It can be directly activated in the console for each service if we need to.

The terraform docs for [product_enablement](https://registry.terraform.io/providers/fastly/fastly/6.0.0/docs/resources/service_vcl#nested-schema-for-product_enablement) and [ddos_protection](https://registry.terraform.io/providers/fastly/fastly/6.0.0/docs/resources/service_vcl#ddos_protection-2) refer to the [Product Enablement API](https://registry.terraform.io/providers/fastly/fastly/latest/docs/guides/product_enablement)

The [options for the mode](https://www.fastly.com/documentation/reference/api/products/ddos_protection/) are "off", "log" or "block"