### PR TITLE
Activate observability features on gov.uk services

### DIFF
--- a/assets/service.tf
+++ b/assets/service.tf
@@ -55,6 +55,9 @@ resource "fastly_service_vcl" "service" {
       enabled = true
       mode    = "log"
     }
+    domain_inspector      = true
+    log_explorer_insights = true
+    origin_inspector      = true
   }
 
   vcl {

--- a/www/service.tf
+++ b/www/service.tf
@@ -73,6 +73,9 @@ resource "fastly_service_vcl" "service" {
       enabled = true
       mode    = "log"
     }
+    domain_inspector      = true
+    log_explorer_insights = true
+    origin_inspector      = true
   }
 
   vcl {


### PR DESCRIPTION
[These](https://registry.terraform.io/providers/fastly/fastly/6.0.0/docs/resources/service_vcl#nested-schema-for-product_enablement) toggle on the [observability features](https://www.fastly.com/documentation/guides/observability/) we've paid for.

As we paid for a quota on these features, I'm purposely only activating on the services I'm especially interested in at the moment.

Bouncer has a _lot_ of domains, so it's probably worth a conversation with Fastly before we activate Domain Inspector on that service.