### PR TITLE
Enable DDOS protection blocking mode on bouncer

### DIFF
--- a/bouncer/service.tf
+++ b/bouncer/service.tf
@@ -28,7 +28,7 @@ resource "fastly_service_vcl" "service" {
   product_enablement {
     ddos_protection {
       enabled = true
-      mode    = "log"
+      mode    = "block"
     }
   }
 


### PR DESCRIPTION
This is in advance of other services.

As an endpoint for thousands of domains, bouncer is often subject to attacks so this is an easier service to trial than others.

Valid options are `off`, `log`, `block`: https://www.fastly.com/documentation/reference/api/products/ddos_protection/

Setting the mode to block means that traffic from detected attacks will be dropped. It's possible to [override the response to each event](https://manage.fastly.com/security/ddos/protection/events/), or just use the default setting configured for the service (which is what this is)

[Some initial docs](https://github.com/alphagov/govuk-developer-docs/pull/5162) for this have been added