### PR TITLE
Enable DDOS blocking on DGU and domain redirects

### DIFF
--- a/datagovuk/service.tf
+++ b/datagovuk/service.tf
@@ -62,7 +62,7 @@ resource "fastly_service_vcl" "service" {
   product_enablement {
     ddos_protection {
       enabled = true
-      mode    = "log"
+      mode    = "block"
     }
   }
 

--- a/service-domain-redirect/service.tf
+++ b/service-domain-redirect/service.tf
@@ -9,7 +9,7 @@ resource "fastly_service_vcl" "service" {
   product_enablement {
     ddos_protection {
       enabled = true
-      mode    = "log"
+      mode    = "block"
     }
   }
 

--- a/tld-redirect/service.tf
+++ b/tld-redirect/service.tf
@@ -13,7 +13,7 @@ resource "fastly_service_vcl" "service" {
   product_enablement {
     ddos_protection {
       enabled = true
-      mode    = "log"
+      mode    = "block"
     }
   }
 


### PR DESCRIPTION
Enabling blocking mode for the next tranche of services:
- data.gov.uk
- the redirect for gov.uk --> www.gov.uk
- the redirect for service.gov.uk --> www.gov.uk

I've reviewed the [historical data for past attacks](https://manage.fastly.com/security/ddos/protection/events) back to 30th May, and am confident that no false positives have been registered. I'm happy that we should enable protection on some more services that are not in the critical path.

Similar to https://github.com/alphagov/govuk-fastly/pull/182