### PR TITLE
Enable observability on other services

### DIFF
--- a/bouncer/service.tf
+++ b/bouncer/service.tf
@@ -30,6 +30,9 @@ resource "fastly_service_vcl" "service" {
       enabled = true
       mode    = "block"
     }
+    domain_inspector      = true
+    log_explorer_insights = true
+    origin_inspector      = true
   }
 
   vcl {

--- a/datagovuk/service.tf
+++ b/datagovuk/service.tf
@@ -64,6 +64,9 @@ resource "fastly_service_vcl" "service" {
       enabled = true
       mode    = "block"
     }
+    domain_inspector      = true
+    log_explorer_insights = true
+    origin_inspector      = true
   }
 
   vcl {

--- a/mobile-backend/service.tf
+++ b/mobile-backend/service.tf
@@ -28,6 +28,9 @@ resource "fastly_service_vcl" "mobile_backend_service" {
       enabled = true
       mode    = "log"
     }
+    domain_inspector      = true
+    log_explorer_insights = true
+    origin_inspector      = true
   }
 
   backend {

--- a/service-domain-redirect/service.tf
+++ b/service-domain-redirect/service.tf
@@ -11,6 +11,9 @@ resource "fastly_service_vcl" "service" {
       enabled = true
       mode    = "block"
     }
+    domain_inspector      = true
+    log_explorer_insights = true
+    origin_inspector      = true
   }
 
   vcl {

--- a/tld-redirect/service.tf
+++ b/tld-redirect/service.tf
@@ -15,6 +15,9 @@ resource "fastly_service_vcl" "service" {
       enabled = true
       mode    = "block"
     }
+    domain_inspector      = true
+    log_explorer_insights = true
+    origin_inspector      = true
   }
 
   vcl {


### PR DESCRIPTION
This is really useful, so let's turn it on for the remaining services.

Bouncer already has this clickopsed, so should already be receiving additional metrics.