### PR TITLE
Enable DDOS blocking on assets, www and mobile

### DIFF
--- a/assets/service.tf
+++ b/assets/service.tf
@@ -53,7 +53,7 @@ resource "fastly_service_vcl" "service" {
   product_enablement {
     ddos_protection {
       enabled = true
-      mode    = "log"
+      mode    = "block"
     }
     domain_inspector      = true
     log_explorer_insights = true

--- a/mobile-backend/service.tf
+++ b/mobile-backend/service.tf
@@ -26,7 +26,7 @@ resource "fastly_service_vcl" "mobile_backend_service" {
   product_enablement {
     ddos_protection {
       enabled = true
-      mode    = "log"
+      mode    = "block"
     }
   }
 

--- a/www/service.tf
+++ b/www/service.tf
@@ -71,7 +71,7 @@ resource "fastly_service_vcl" "service" {
   product_enablement {
     ddos_protection {
       enabled = true
-      mode    = "log"
+      mode    = "block"
     }
     domain_inspector      = true
     log_explorer_insights = true


### PR DESCRIPTION
I've reviewed the historical events for false positives. They all look reasonable to me.

We've previously enabled the blocking protection on data.gov.uk, bouncer and the redirection services without issue.

There are docs around [unblocking rules if necessary](https://docs.publishing.service.gov.uk/manual/cdn.html#unblocking-legitimate-traffic), or just revert the necessary lines here and deploy.

I have advised Senior Tech and Mike S that this is going ahead.

Similar to #182 and #183 