### PR TITLE
Introduce a named query for finding 5xx error rates in Fastly logs

### DIFF
--- a/logs/saved_queries.tf
+++ b/logs/saved_queries.tf
@@ -1,0 +1,19 @@
+resource "aws_athena_named_query" "http_5xx_error_counts_today" {
+  database = aws_glue_catalog_database.fastly_logs.name
+  name     = "http_5xx_count_by_path_today"
+  query    = <<-QUERY
+select
+    url, status, count(1) as "count"
+from
+    ${aws_glue_catalog_table.govuk_www.name}
+where
+        date >= day(NOW())
+    and month >= month(NOW())
+    and year >= year(NOW())
+    and status between 499 and 600
+group by
+    url, status
+order by
+    "count" desc
+QUERY
+}


### PR DESCRIPTION
We have a runbook to support diagnosing and handling incidences of spikes in HTTP 5xx error rates. The run book contains this query, but we'd also like to have it saved and ready for use in the Athena console.