### PR TITLE
Globally pin GitHub Actions actions to commit hashes not tags

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,7 +6,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           show-progress: false
       - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main

--- a/.github/workflows/build_diff_gen_image.yaml
+++ b/.github/workflows/build_diff_gen_image.yaml
@@ -32,7 +32,7 @@ jobs:
       id-token: write
       packages: write
     steps:
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -9,7 +9,7 @@ jobs:
   tflint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       with:
         show-progress: false
 
@@ -17,7 +17,7 @@ jobs:
       uses: dflook/terraform-version@33f9a69ab2950c83a6d3a8626f35075481a64ca0
       id: terraform-version
 
-    - uses: hashicorp/setup-terraform@v3
+    - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       with:
         terraform_version: ${{ steps.terraform-version.outputs.terraform }}
         terraform_wrapper: false
@@ -26,19 +26,19 @@ jobs:
       run: mkdir -p "$TF_PLUGIN_CACHE_DIR"
 
     - name: Cache Terraform plugins
-      uses: actions/cache@v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: ${{ env.TF_PLUGIN_CACHE_DIR }}
         key:
           terraform-plugins-${{ runner.os }}-${{ hashFiles('**/.terraform.lock.hcl') }}
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       name: Cache TFLint plugins
       with:
         path: ~/.tflint.d/plugins
         key: tflint-${{ runner.os }}-${{ hashFiles('**/tflint.hcl') }}
 
-    - uses: terraform-linters/setup-tflint@v4
+    - uses: terraform-linters/setup-tflint@90f302c255ef959cbfb4bd10581afecdb7ece3e6 # v4.1.1
       name: Set up TFLint
       with:
         tflint_version: v0.47.0


### PR DESCRIPTION
We agree that pinning the versions of GitHub Actions actions to a commit hash
instead of a mutable tag is the correct choice.

We have a lot of places where we use them. The changes in this commit were
generated by using a tool called pinact[1] which can convert pinned tags in GHA
workflows to the commit hash they point to at that moment in time.

To generate the change set I ran `pinact run` from the root of the repository.

[1] https://github.com/suzuki-shunsuke/pinact
