### PR TITLE
Strip params to /prepare path

### DIFF
--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -263,6 +263,12 @@ sub vcl_recv {
     # get rid of all query parameters
     set req.url = querystring.remove(req.url);
   }
+
+  if (req.url.path == "/prepare") {
+    # get rid of all query parameters
+    set req.url = querystring.remove(req.url);
+  }
+
   %{ if contains(["staging", "production"], environment) }
   # Save original request url because req.url changes after restarts.
   if (req.restarts < 1) {


### PR DESCRIPTION
In the expectation of comms and other publicity which might contain query params

This is only stripped for processing in the CDN and therefore improves our caching capabilities.