### PR TITLE
Re-enable blocking on www services

### DIFF
--- a/www/service.tf
+++ b/www/service.tf
@@ -71,7 +71,7 @@ resource "fastly_service_vcl" "service" {
   product_enablement {
     ddos_protection {
       enabled = true
-      mode    = "log"
+      mode    = "block"
     }
     domain_inspector      = true
     log_explorer_insights = true


### PR DESCRIPTION
This partially reverts https://github.com/alphagov/govuk-fastly/pull/197 and allows granular reapplication of blocking mode to the www services (integration, staging and production).