### PR TITLE
Re-enable blocking on assets

### DIFF
--- a/assets/service.tf
+++ b/assets/service.tf
@@ -53,7 +53,7 @@ resource "fastly_service_vcl" "service" {
   product_enablement {
     ddos_protection {
       enabled = true
-      mode    = "log"
+      mode    = "block"
     }
     domain_inspector      = true
     log_explorer_insights = true


### PR DESCRIPTION
This partially reverts https://github.com/alphagov/govuk-fastly/pull/197 and allows granular reapplication of blocking mode to the assets services (integration, staging and production).