### PR TITLE
Re-enable blocking on tld redirect services

### DIFF
--- a/tld-redirect/service.tf
+++ b/tld-redirect/service.tf
@@ -13,7 +13,7 @@ resource "fastly_service_vcl" "service" {
   product_enablement {
     ddos_protection {
       enabled = true
-      mode    = "log"
+      mode    = "block"
     }
     domain_inspector      = true
     log_explorer_insights = true


### PR DESCRIPTION
This partially reverts https://github.com/alphagov/govuk-fastly/pull/197 and allows granular reapplication of blocking mode to the tld redirect services (integration, staging and production).