### PR TITLE
Revert "Strip params to /prepare path"

### DIFF
--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -263,12 +263,6 @@ sub vcl_recv {
     # get rid of all query parameters
     set req.url = querystring.remove(req.url);
   }
-
-  if (req.url.path == "/prepare") {
-    # get rid of all query parameters
-    set req.url = querystring.remove(req.url);
-  }
-
   %{ if contains(["staging", "production"], environment) }
   # Save original request url because req.url changes after restarts.
   if (req.restarts < 1) {


### PR DESCRIPTION
Reverts alphagov/govuk-fastly#198

This is just a standard redirect now. We should treat it like the others.