### PR TITLE
Remove duplicate headers config

### DIFF
--- a/datagovuk/datagovuk.vcl.tftpl
+++ b/datagovuk/datagovuk.vcl.tftpl
@@ -72,11 +72,6 @@ sub vcl_recv {
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
 
-  # Reset proxy headers at the boundary to our network.
-  unset req.http.Client-IP;
-  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
-  set req.http.X-Forwarded-Host = req.http.host;
-
   %{ if basic_authentication != null }
   if (! (client.ip ~ allowed_ip_addresses)) {
     # Check whether the basic auth credentials are correct in integration

--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -179,11 +179,6 @@ sub vcl_recv {
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
 
-  # Reset proxy headers at the boundary to our network.
-  unset req.http.Client-IP;
-  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
-  set req.http.X-Forwarded-Host = req.http.host;
-
   if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
     set req.http.Client-JA3 = tls.client.ja3_md5;
   }


### PR DESCRIPTION
The configuration removed here is already included in the VCL files via the [shared boundary headers include](https://github.com/alphagov/govuk-fastly/blob/b4f65566984264e6bf9d42e9786dd3eb99c95329/shared/_boundary_headers.vcl.tftpl)

`${indent(2, file("${module_path}/../shared/_boundary_headers.vcl.tftpl"))}`

The shared config is [included in the www config on line 177](https://github.com/alphagov/govuk-fastly/blob/b4f65566984264e6bf9d42e9786dd3eb99c95329/www/www.vcl.tftpl#L177) and [included in the DGU config on line 48](https://github.com/alphagov/govuk-fastly/blob/b4f65566984264e6bf9d42e9786dd3eb99c95329/datagovuk/datagovuk.vcl.tftpl#L48).

The post-plan vcl diff lambda is now working, so you can see the differences like a human would want to.

Open one of the TF cloud checks, unfurl the Post-plan Passed section. The vcl-diff run is in the `All` tab.
<img width="1137" height="429" alt="Screenshot 2025-09-11 at 10 52 13" src="https://github.com/user-attachments/assets/ed967f15-9c5f-4bbc-afbb-4fb0ee5fe79e" />
