### PR TITLE
Update the user agent for the mirror crawler

### DIFF
--- a/www/_multivariate_tests.vcl.tftpl
+++ b/www/_multivariate_tests.vcl.tftpl
@@ -4,7 +4,7 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
 %{ for test_config in ab_tests ~}
 %{ for test, variants in test_config ~}
   if (table.lookup(active_ab_tests, "${test}") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    if (req.http.User-Agent ~ "^govuk-mirror-bot") {
       set req.http.GOVUK-ABTest-${test} = "${variants[0]}";
 %{ for variant in variants ~}
     } else if (req.url ~ "[\?\&]ABTest-${test}=${variant}(&|$)") {

--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -544,7 +544,7 @@ sub vcl_deliver {
   # ensures that most visitors to the site aren't assigned an irrelevant test
   # cookie.
   if (req.url ~ "^/help/ab-testing"
-    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.User-Agent !~ "^govuk-mirror-bot"
     && req.http.GOVUK-ABTest-Example-Cookie != "sent_in_request") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
@@ -552,7 +552,7 @@ sub vcl_deliver {
 
 %{ if ab_tests != [] ~}
   declare local var.expiry TIME;
-  if (req.http.Usage-Cookies-Opt-In == "true" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+  if (req.http.Usage-Cookies-Opt-In == "true" && req.http.User-Agent !~ "^govuk-mirror-bot") {
 %{ for test_config in ab_tests ~}
 %{ for test, _ in test_config ~}
 %{ if test != "Example" ~}


### PR DESCRIPTION
This ensures that the crawler gets the default version of any pages in AB testing.

There used to be a [GOV.UK Crawler Worker](https://github.com/alphagov/govuk_crawler_worker) but that's archived, and we're now using [govuk-mirror](https://github.com/alphagov/govuk-mirror/blob/449dab1ac4e9ec33f517c45ceaea3d1cd3758fa3/internal/config/config.go#L13)