### PR TITLE
Remove search freshness AB test

### DIFF
--- a/dictionaries.yaml
+++ b/dictionaries.yaml
@@ -1,11 +1,9 @@
 active_ab_tests:
   Example: true
   BankHolidaysTest: true
-  SearchFreshnessBoost: true
 ab_test_expiries:
   Example: 86400
   BankHolidaysTest: 86400
-  SearchFreshnessBoost: 86400
 # AB test percentages
 example_percentages:
   A: 50
@@ -13,10 +11,6 @@ example_percentages:
 bankholidaystest_percentages:
   A: 99
   B: 1
-searchfreshnessboost_percentages:
-  A: 0
-  B: 0
-  Z: 100
 # Dictionary for /bank-holidays.json rate limiter
 bankholidaysjson_ratelimiter:
   '/bank-holidays.json': 'Bank Holidays JSON'

--- a/www/ab_tests.yaml
+++ b/www/ab_tests.yaml
@@ -7,7 +7,3 @@
 - BankHolidaysTest:
   - A
   - B
-- SearchFreshnessBoost:
-  - A
-  - B
-  - Z


### PR DESCRIPTION
The [AB testing register](https://docs.google.com/spreadsheets/d/1h4vGXzIbhOWwUzourPLIc8WM-iU1b6WYOVDOZxmU1Uo/edit?gid=254065189#gid=254065189) indicates that this finished in April.

[There are docs for removing a test](https://docs.publishing.service.gov.uk/manual/run-ab-test.html#4-remove-the-ab-test)

Needs verification from the product team though.