### PR TITLE
Clean up www service VCL a bit

### DIFF
--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -719,8 +719,6 @@ sub vcl_error {
   return (deliver);
 }
 
-# pipe cannot be included.
-
 sub vcl_pass {
 #FASTLY pass
 }


### PR DESCRIPTION
VCL files are quite hard to work with, so I'm trying to clean them up a little to help.

I've removed a redundant `if` statement. The code is already wrapped by an identical statement, so this should have no effect.

I've ensured that each of the VCL subroutines (vcl_recv, vcl_fetch, vcl_deliver, vcl_hit, vcl_miss, vcl_error, vcl_pass) have a comment on the first line matching the established pattern, e.g. `#FASTLY recv`

This has the benefit of tidying them up (as some were in the depths of the subroutines, and some were missing), but also helps in IDEs like VSCode allow folding on comments/indentation. 

I've also removed a weird comment. Google sheds no light, but it feels like it might have been an error generated when concatenating files together.