### PR TITLE
Add comment about 829 errors

### DIFF
--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -615,34 +615,6 @@ sub vcl_error {
     return (deliver);
   }
 
-  if (obj.status == 829) {
-    set obj.status = 429;
-    set obj.response = "Too Many Requests";
-    set obj.http.Fastly-Backend-Name = "too_many_requests";
-
-    synthetic {"
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <title>Welcome to GOV.UK</title>
-          <style>
-            body { font-family: Arial, sans-serif; margin: 0; }
-            header { background: black; }
-            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
-            p { color: black; margin: 30px auto; max-width: 990px; }
-          </style>
-        </head>
-        <body>
-          <header><h1>GOV.UK</h1></header>
-          <p>Sorry, there have been too many attempts to access this page.</p>
-          <p>Try again in a few minutes.</p>
-        </body>
-      </html>
-    "};
-
-    return (deliver);
-  }
-
   if (obj.status == 806) {
         set obj.status = 501;
         set obj.response = "Not Implemented";


### PR DESCRIPTION
829 errors aren't obviously generated in our code anywhere, so adding a comment giving a hint as to its use. 

[Rate limiters are configured in Terraform](https://github.com/alphagov/govuk-fastly/blob/c1919d43d0e2fb4eaf9c87b7c029a2923c781434/www/service.tf#L133-L170) at present.