### PR TITLE
Remove hand-coded 829 error section

### DIFF
--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -615,34 +615,6 @@ sub vcl_error {
     return (deliver);
   }
 
-  if (obj.status == 829) {
-    set obj.status = 429;
-    set obj.response = "Too Many Requests";
-    set obj.http.Fastly-Backend-Name = "too_many_requests";
-
-    synthetic {"
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <title>Welcome to GOV.UK</title>
-          <style>
-            body { font-family: Arial, sans-serif; margin: 0; }
-            header { background: black; }
-            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
-            p { color: black; margin: 30px auto; max-width: 990px; }
-          </style>
-        </head>
-        <body>
-          <header><h1>GOV.UK</h1></header>
-          <p>Sorry, there have been too many attempts to access this page.</p>
-          <p>Try again in a few minutes.</p>
-        </body>
-      </html>
-    "};
-
-    return (deliver);
-  }
-
   if (obj.status == 806) {
         set obj.status = 501;
         set obj.response = "Not Implemented";


### PR DESCRIPTION
The terraform that generates our edge-rate limiting is the only thing that generates 829 errors in our VCL. The terraform also generates code that handles the errors. It's in the "complete VCL" in the Fastly console, and looks a bit like this:

```
"# Snippet rate-limiter-v1-someid-error-error : 100
"# Begin rate-limiter rate_limiter error
  if (obj.status == 829 && obj.response == "Rate limiter: Too many requests for someid") {
    set obj.status = 429;
    set obj.response = "Too Many Requests";
    set obj.http.Content-Type = "plain/text";
    synthetic.base64 "VG9vIG1hbnkgcmVxdWVzdHM=";
    return(deliver);
  }
```

## First terraform-generated section 

<img width="1301" height="538" alt="Screenshot 2025-09-12 at 09 56 03" src="https://github.com/user-attachments/assets/e4e864c6-71b4-442a-9b9f-2dc45ce2f769" />

## Second terraform-generated section

<img width="1284" height="530" alt="Screenshot 2025-09-12 at 09 57 42" src="https://github.com/user-attachments/assets/4889493c-a0a7-44bf-b07b-7bcfba8562ba" />


## Our code that I'd like to remove

<img width="1156" height="694" alt="Screenshot 2025-09-12 at 09 58 01" src="https://github.com/user-attachments/assets/e9330679-8e4a-49df-a57b-f46c8bc1d9c0" />


It's notable that we set a `Fastly-Backend-Name` that, I think should appear in the origins inspector along with the S3 buckets, but doesn't. I'm taking this as being further evidence that this isn't a code path that's executed.

If we wanted to examine this further, we could possibly instrument this section in some way, or use a "beacon" in the markup that we send back.