### PR TITLE
Disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,1 @@
-version: 2
-updates:
-  - package-ecosystem: pip
-    directory: /diff-generator/
-    schedule:
-      interval: daily
-  - package-ecosystem: terraform
-    directories:
-      - /assets
-      - /bouncer
-      - /datagovuk
-      - /logs
-      - /mobile-backend
-      - /service-domain-redirect
-      - /tld-redirect
-      - /www
-    schedule:
-      interval: daily
+---


### PR DESCRIPTION
Disable Dependabot for all dependencies while the npmjs security incident is ongoing