### PR TITLE
Update header styles

### DIFF
--- a/bouncer/bouncer.vcl.tftpl
+++ b/bouncer/bouncer.vcl.tftpl
@@ -132,7 +132,7 @@ sub vcl_error {
           <title>Welcome to GOV.UK</title>
           <style>
             body { font-family: Arial, sans-serif; margin: 0; }
-            header { background: black; }
+            header { background: #1d70b8; }
             h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
             p { color: black; margin: 30px auto; max-width: 990px; }
           </style>
@@ -161,7 +161,7 @@ sub vcl_error {
         <title>GOV.UK Redirect</title>
         <style>
           body { font-family: Arial, sans-serif; margin: 0; }
-          header { background: black; }
+          header { background: #1d70b8; }
           h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
           p { color: black; margin: 30px auto; max-width: 990px; }
         </style>

--- a/datagovuk/datagovuk.vcl.tftpl
+++ b/datagovuk/datagovuk.vcl.tftpl
@@ -228,7 +228,7 @@ sub vcl_error {
         <title>Welcome to Find open data - data.gov.uk</title>
         <style>
           body { font-family: Arial, sans-serif; margin: 0; }
-          header { background: black; }
+          header { background: #1d70b8; }
           h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
           p { color: black; margin: 30px auto; max-width: 990px; }
         </style>

--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -601,7 +601,7 @@ sub vcl_error {
           <title>Welcome to GOV.UK</title>
           <style>
             body { font-family: Arial, sans-serif; margin: 0; }
-            header { background: black; }
+            header { background: #1d70b8; }
             h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
             p { color: black; margin: 30px auto; max-width: 990px; }
           </style>
@@ -627,7 +627,7 @@ sub vcl_error {
           <title>Welcome to GOV.UK</title>
           <style>
             body { font-family: Arial, sans-serif; margin: 0; }
-            header { background: black; }
+            header { background: #1d70b8; }
             h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
             p { color: black; margin: 30px auto; max-width: 990px; }
           </style>
@@ -655,7 +655,7 @@ sub vcl_error {
               <title>Welcome to GOV.UK</title>
               <style>
                 body { font-family: Arial, sans-serif; margin: 0; }
-                header { background: black; }
+                header { background: #1d70b8; }
                 h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
                 p { color: black; margin: 30px auto; max-width: 990px; }
               </style>
@@ -705,7 +705,7 @@ sub vcl_error {
         <title>Welcome to GOV.UK</title>
         <style>
           body { font-family: Arial, sans-serif; margin: 0; }
-          header { background: black; }
+          header { background: #1d70b8; }
           h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
           p { color: black; margin: 30px auto; max-width: 990px; }
         </style>


### PR DESCRIPTION
## What

Update header styles to match new GOV.UK brand refresh.

## Visual changes

### Before

<img width="1542" height="400" alt="about_blank (1)" src="https://github.com/user-attachments/assets/6ec2376a-8aea-430a-806b-902f0c0ee6d2" />

### After

<img width="1542" height="400" alt="about_blank" src="https://github.com/user-attachments/assets/2533a9d5-8f23-4dfd-97b8-489bba0b95a9" />