### PR TITLE
Introduce 10 day cooldown period for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,24 @@
+---
 version: 2
 updates:
-  - package-ecosystem: pip
-    directory: /diff-generator/
-    schedule:
-      interval: daily
-  - package-ecosystem: terraform
-    directories:
-      - /assets
-      - /bouncer
-      - /datagovuk
-      - /logs
-      - /mobile-backend
-      - /service-domain-redirect
-      - /tld-redirect
-      - /www
-    schedule:
-      interval: daily
+- package-ecosystem: pip
+  directory: /diff-generator/
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 10
+- package-ecosystem: terraform
+  directories:
+  - /assets
+  - /bouncer
+  - /datagovuk
+  - /logs
+  - /mobile-backend
+  - /service-domain-redirect
+  - /tld-redirect
+  - /www
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 10
+...


### PR DESCRIPTION
## What

Adds 10 day dependency cooldowns for Dependabot and Renovate as appropriate
