### PR TITLE
Extend asset caching for datagovuk to cover /assets

### DIFF
--- a/datagovuk/datagovuk.vcl.tftpl
+++ b/datagovuk/datagovuk.vcl.tftpl
@@ -182,8 +182,8 @@ sub vcl_fetch {
   }
 
   %{ if contains(["staging", "production"], environment) ~}
-  # Set the Cache-Control header for /find-assets/ and sub-paths for 1 year
-  if (req.url ~ "^/(find-assets|javascript)/" && beresp.status == 200) {
+  # Set the Cache-Control header for asset-related sub-paths for 1 year
+  if (req.url ~ "^/(find-assets|javascript|assets)/" && beresp.status == 200) {
     set beresp.http.Cache-Control = "public, max-age=31536000, immutable";
     set beresp.ttl = 31536000s;
   }


### PR DESCRIPTION
This change extend far-future expiry asset caching for datagovuk to cover /assets.  This is a new assets endpoint which is used by responses by the new datagovuk django application.