### PR TITLE
Assets: Look-up keepalive_time, default to 0.

### DIFF
--- a/assets/service.tf
+++ b/assets/service.tf
@@ -93,7 +93,7 @@ resource "fastly_service_vcl" "service" {
       ssl_cert_hostname = each.value.address
       ssl_sni_hostname  = each.value.address
       shield            = lookup(each.value, "shield", "london-uk")
-      keepalive_time    = 0
+      keepalive_time    = lookup(each.value, "keepalive_time", 0)
       healthcheck       = ""
       max_tls_version   = ""
       min_tls_version   = ""


### PR DESCRIPTION
## What?
This changes the `keepalive_time` value on assets-origin to use the look-up value. If it is not set, it defaults to the previous value of `0`.