### PR TITLE
Fastly Origin Shielding was not in VCL config.

### DIFF
--- a/assets/assets.vcl.tftpl
+++ b/assets/assets.vcl.tftpl
@@ -6,6 +6,7 @@ backend F_awsorigin {
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
+    .shield = "${shield}"
 
     .ssl = true;
     .ssl_check_cert = always;

--- a/assets/assets.vcl.tftpl
+++ b/assets/assets.vcl.tftpl
@@ -6,7 +6,7 @@ backend F_awsorigin {
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .shield = "${shield}"
+    .shield = "${shield}";
 
     .ssl = true;
     .ssl_check_cert = always;
@@ -172,22 +172,25 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
+  # Shared boundary headers
   ${indent(2, file("${module_path}/../shared/_boundary_headers.vcl.tftpl"))}
 
-  # Enable real time logging of JA3 signatures for future analysis
+  # Edge-only processing (run once at outer edge POP - skip the shield POP)
   if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    # Enable real time logging of JA3 signatures for future analysis
     set req.http.Client-JA3 = tls.client.ja3_md5;
-  }
 
-  # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
-    set req.http.Fastly-Purge-Requires-Auth = "1";
-  }
+    # Require authentication for FASTLYPURGE requests unless from IP in ACL
+    if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
+      set req.http.Fastly-Purge-Requires-Auth = "1";
+    }
 
-  # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_denylist, client.ip)) {
-    error 403 "Forbidden";
+    # Check whether the remote IP address is in the list of blocked IPs
+    if (table.lookup(ip_address_denylist, client.ip)) {
+      error 403 "Forbidden";
+    }
   }
+  # END: Edge-only processing
 
   # Force SSL.
   if (!req.http.Fastly-SSL) {

--- a/assets/service.tf
+++ b/assets/service.tf
@@ -13,6 +13,9 @@ locals {
       basic_authentication = null
       probe_dns_only       = false
 
+      # Default Origin Shield location
+      shield = "london-uk"
+
       keepalive_time = 0
 
       # these values are needed even if mirrors aren't enabled in an environment

--- a/www/service.tf
+++ b/www/service.tf
@@ -26,6 +26,9 @@ locals {
       ssl_ciphers          = "ECDHE-RSA-AES256-GCM-SHA384"
       basic_authentication = null
 
+      # Default Origin Shield location
+      shield = "london-uk"
+
       s3_static_assets_port     = 443
       s3_static_assets_hostname = null
 
@@ -259,4 +262,3 @@ resource "fastly_service_dictionary_items" "items" {
   items         = local.dictionaries[each.key]
   manage_items  = true
 }
-

--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -10,6 +10,8 @@ backend F_origin {
     .max_connections = 200;
     .between_bytes_timeout = 10s;
 
+    .shield = "${shield}";
+
     .ssl = true;
     .ssl_check_cert = always;
     .min_tls_version = "${minimum_tls_version}";
@@ -261,7 +263,7 @@ sub vcl_recv {
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
   }
-  
+
   # Reject unimplemented and non-standard HTTP methods
   if (req.method !~ "^(GET|HEAD|POST|PUT|DELETE|OPTIONS|PATCH|FASTLYPURGE)") {
     error 806 "Not Implemented";

--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -216,41 +216,46 @@ sub apply_rate_limit_global {
 sub vcl_recv {
   declare local var.backend_override STRING;
 
+  # Shared boundary headers
   ${indent(2, file("${module_path}/../shared/_boundary_headers.vcl.tftpl"))}
 
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
 
+  # Edge-only processing (run once at outer edge POP - skip the shield POP)
   if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
     set req.http.Client-JA3 = tls.client.ja3_md5;
-  }
 
-  %{ if environment == "staging" }
-  # Only allow connections from allowed IP addresses in staging
-  if (! (req.http.True-Client-IP ~ allowed_ip_addresses)) {
-    error 403 "Forbidden";
-  }
-  %{ endif ~}
+    # Set a unique request id at the outer edge to trace requests end-to-end
+    set req.http.GOVUK-Request-Id = uuid.version4();
 
-  # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_denylist, client.ip)) {
-    error 403 "Forbidden";
-  }
+    %{ if environment == "staging" }
+    # Only allow connections from allowed IP addresses in staging
+    if (! (req.http.True-Client-IP ~ allowed_ip_addresses)) {
+      error 403 "Forbidden";
+    }
+    %{ endif ~}
 
-  # Block requests that match a known bad signature
-  if (req.restarts == 0 && fastly.ff.visits_this_service == 0) {
+    # Check whether the remote IP address is in the list of blocked IPs
+    if (table.lookup(ip_address_denylist, client.ip)) {
+      error 403 "Forbidden";
+    }
+
+    # Block requests that match a known bad signature
     if (table.lookup(ja3_signature_denylist, req.http.Client-JA3, "false") == "true") {
       error 403 "Forbidden";
     }
-  }
-  %{ if basic_authentication != null }
-  if (! (client.ip ~ allowed_ip_addresses)) {
-    # Check whether the basic auth credentials are correct in integration
-    if (req.http.Authorization != "Basic ${basic_authentication}") {
-      error 401 "Unauthorized";
+
+    %{ if basic_authentication != null }
+    if (! (client.ip ~ allowed_ip_addresses)) {
+      # Check whether the basic auth credentials are correct in integration
+      if (req.http.Authorization != "Basic ${basic_authentication}") {
+        error 401 "Unauthorized";
+      }
     }
+    %{ endif ~}
   }
-  %{ endif ~}
+  # END: Edge-only processing
 
   # Strip Accept-Encoding header if the content is already compressed
   if (req.http.Accept-Encoding) {
@@ -284,13 +289,9 @@ sub vcl_recv {
   # Serve from stale for 24 hours if origin is sick
   set req.max_stale_if_error = 24h;
 
-  # Default backend, these details will be overwritten if other backends are
-  # chosen
+  # Default backend, these details will be overwritten if other backends are chosen
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
-
-  # Set a request id header to allow requests to be traced through the stack
-  set req.http.GOVUK-Request-Id = uuid.version4();
 
   if (req.url.path == "/") {
     # get rid of all query parameters


### PR DESCRIPTION
## What?
It turns out that we tried to configure Fastly Origin Shielding with a default for "london-uk" in our Terraform resources for the `assets` and `www` services:
```hcl
shield = lookup(each.value, "shield", "london-uk")
```

...but as the property wasn't in our VCL template file, it's not been doing anything (as far as I can tell). This adds it to the VCL templates to actually enable [Fastly Origin Shielding](https://www.fastly.com/documentation/guides/concepts/shielding/) which should hopefully reduce the number of hits (and latency) on our backends.

Have also pushed some tweaks at `sub vcl_recv {}` to try and avoid any issues that could arise from having multiple POPs in the chain, so we should still get the correct Client IP Headers etc.