### PR TITLE
Support multiple basic authentication credentials for the www service

### DIFF
--- a/www/service.tf
+++ b/www/service.tf
@@ -18,6 +18,11 @@ locals {
   formatted_rate_limit_allow_list = [
     for v in local.ratelimit_allow_list_cidrs : format("\"%s\"/%s", split("/", v)[0], split("/", v)[1])
   ]
+  basic_auth_from_secrets = lookup(local.secrets, "basic_authentication", null)
+  basic_authentication_list = (
+    local.basic_auth_from_secrets == null ? [] :
+    can(tolist(local.basic_auth_from_secrets)) ? tolist(local.basic_auth_from_secrets) : [local.basic_auth_from_secrets]
+  )
 
   template_values = merge(
     { # some defaults
@@ -58,7 +63,8 @@ locals {
         "${path.module}/_multivariate_tests.vcl.tftpl",
         { ab_tests = local.ab_tests }
       )
-      module_path = path.module
+      module_path               = path.module
+      basic_authentication_list = local.basic_authentication_list
     },
     var.configuration,
     local.secrets

--- a/www/www.vcl.tftpl
+++ b/www/www.vcl.tftpl
@@ -26,7 +26,7 @@ backend F_origin {
             "User-Agent: Fastly healthcheck"
             "Rate-Limit-Token: ${rate_limit_token}"
 %{ if basic_authentication != null ~}
-            "Authorization: Basic ${basic_authentication}"
+            "Authorization: Basic ${basic_authentication_list[0]}"
 %{ endif ~}
             "Connection: close";
         .threshold = 1;
@@ -244,7 +244,7 @@ sub vcl_recv {
   %{ if basic_authentication != null }
   if (! (client.ip ~ allowed_ip_addresses)) {
     # Check whether the basic auth credentials are correct in integration
-    if (req.http.Authorization != "Basic ${basic_authentication}") {
+    if (${join(" && ", [for val in basic_authentication_list : "req.http.Authorization != \"Basic ${val}\""])}) {
       error 401 "Unauthorized";
     }
   }


### PR DESCRIPTION
## Why

We want to be able to add a temporary credentials to enable 3rd party testing in integration, specifically new HM Passport Office web chat integration.
This will also allow us to rotate the credentials.

#### Other options considered
1. Proxy app e.g. https://github.com/alphagov/govuk-proxy-test-app 
Cons: Time-consuming new repo and archival process

2. Publish a draft special route and issue a bypass auth token 
Cons: not done before, complex and requiring development work in Publishing API

## Implementation details
`can(tolist(...))` detects data type. If the YAML returns plain string, `tolist()` on it fails, `can()` catches that and returns `false`, so it falls into `[value]`.  If YAML returns an actual list, `tolist()` succeeds and it's used as-is.
This ensures both forms are valid, so no immediate migration is needed.

Healthcheck probe uses the first item in the list.

## Changes
This ensures both formats (single value and a list) are valid, so no immediate migration is needed.
Fastly VCL diff shows no changes as expected (no values were added to the secrets):
- https://govuk-fastly-diff.s3.amazonaws.com/run-cSkfbiRJmKC8U5Wi-axvbqsxnktmctrgfyntofpgkkcsclbpwwlwjdvnnzfmtukylppizqtjwkwlacghl.html